### PR TITLE
feat(clipper): add Zilobase web clipper

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -25,6 +25,7 @@
     "patterns": [
       "apps/*",
       "packages/features",
+      "packages/html-to-page",
       "packages/markdown-text-splitter",
       "packages/page-context",
       "packages/tiptap-comment-extension"
@@ -187,6 +188,14 @@
       {
         "name": "package-comment-extension",
         "patterns": ["packages/tiptap-comment-extension/src/**"]
+      },
+      {
+        "name": "package-html-to-page",
+        "patterns": ["packages/html-to-page/src/**"]
+      },
+      {
+        "name": "web-extension",
+        "patterns": ["apps/clipper/**"]
       }
     ],
     "rules": [
@@ -521,6 +530,7 @@
           "server-infrastructure",
           "package-features",
           "package-page-context",
+          "package-html-to-page",
           "server-runtime-contract",
           "server-shared"
         ]
@@ -558,6 +568,19 @@
       {
         "from": "package-comment-extension",
         "allow": ["package-comment-extension"]
+      },
+      {
+        "from": "package-html-to-page",
+        "allow": ["package-html-to-page"]
+      },
+      {
+        "from": "web-extension",
+        "allow": [
+          "web-extension",
+          "web-shared",
+          "package-features",
+          "package-html-to-page"
+        ]
       }
     ]
   },

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ dist
 dist-ssr
 coverage
 .vite
+.output
+.wxt
 target
 *.local
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,3 +13,7 @@ A Database is a page-backed collection of pages with properties, rows, views, an
 ### Page
 
 A Page is the page item represented by a Database row and opened from the editor.
+
+### Clip
+
+A Clip is a webpage captured by the Web Clipper into a Page. It stores the source URL on page metadata, optional database properties, and Tiptap body content converted from sanitized HTML.

--- a/apps/clipper/README.md
+++ b/apps/clipper/README.md
@@ -1,0 +1,13 @@
+# Zilobase Web Clipper
+
+WXT browser extension. Load unpacked from `.output/chrome-mv3` after a build.
+
+```sh
+npm run dev:clipper
+npm run build:clipper
+npm run build --workspace @zilobase/clipper -- -b firefox
+```
+
+`dev:clipper` is not the Zilobase API. It starts WXT’s hot-reload server on `http://localhost:3400` and opens Chrome with the extension loaded. Keep `npm run dev:local` running separately; the clipper still saves to `http://localhost:3000`.
+
+Connect a workspace-scoped API key in the extension options page (`nl_…` from Settings → API Keys).

--- a/apps/clipper/assets/clipper.css
+++ b/apps/clipper/assets/clipper.css
@@ -1,0 +1,34 @@
+@import "tailwindcss";
+@import "../../web/src/shared/styles/color-tokens.css";
+@import "../../web/src/shared/styles/design-tokens.css";
+
+@source "../entrypoints/**/*.{ts,tsx}";
+@source "../components/**/*.{ts,tsx}";
+@source "../../web/src/shared/**/*.{ts,tsx}";
+@source "../../web/src/shared/lib/color-tokens.ts";
+
+@custom-variant dark (&:where(.dark *));
+
+@layer base {
+  * {
+    @apply border-stroke-default outline-action-focus-ring;
+  }
+  html {
+    @apply font-sans;
+  }
+  body {
+    @apply bg-surface-canvas text-content-primary;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+  }
+}
+
+html[data-clipper-popup],
+html[data-clipper-popup] body,
+html[data-clipper-popup] #root {
+  min-width: 360px;
+  max-width: 360px;
+  margin: 0;
+  background: var(--zb-color-surface-background-overlay);
+}

--- a/apps/clipper/entrypoints/background.ts
+++ b/apps/clipper/entrypoints/background.ts
@@ -1,0 +1,25 @@
+import { defineBackground } from "wxt/utils/define-background"
+import { browser } from "wxt/browser"
+
+export default defineBackground(() => {
+  browser.contextMenus.create({
+    id: "zilobase-clip-page",
+    title: "Save page to Zilobase",
+    contexts: ["page"],
+  })
+  browser.contextMenus.create({
+    id: "zilobase-clip-selection",
+    title: "Save selection to Zilobase",
+    contexts: ["selection"],
+  })
+
+  browser.contextMenus.onClicked.addListener(() => {
+    void browser.action.openPopup()
+  })
+
+  browser.commands.onCommand.addListener((command) => {
+    if (command === "open-clipper" || command === "quick-clip") {
+      void browser.action.openPopup()
+    }
+  })
+})

--- a/apps/clipper/entrypoints/extract.content.ts
+++ b/apps/clipper/entrypoints/extract.content.ts
@@ -1,0 +1,61 @@
+import { extractClipMetadata } from "@zilobase/html-to-page/extract-clip-metadata"
+import type { ClipCaptureMode } from "@zilobase/features/clips"
+import { defineContentScript } from "wxt/utils/define-content-script"
+import { browser } from "wxt/browser"
+
+import { isExtractMessage, type ExtractResult } from "../lib/messages"
+
+export default defineContentScript({
+  matches: ["<all_urls>"],
+  runAt: "document_idle",
+  main() {
+    browser.runtime.onMessage.addListener((message) => {
+      if (!isExtractMessage(message)) return
+      return Promise.resolve(extractPage(message.captureMode))
+    })
+  },
+})
+
+function extractPage(captureMode: ClipCaptureMode): ExtractResult {
+  const selection = window.getSelection()
+  const selectionHtml = selection?.rangeCount
+    ? fragmentHtml(selection.getRangeAt(0).cloneContents())
+    : ""
+  const selectionPresent = Boolean(selectionHtml.trim() || selection?.toString().trim())
+  const html =
+    captureMode === "selection"
+      ? selectionHtml || `<p>${escapeHtml(selection?.toString() ?? "")}</p>`
+      : captureMode === "bookmark"
+        ? ""
+        : captureMode === "page"
+          ? document.body?.innerHTML ?? ""
+          : articleHtml()
+
+  return {
+    html,
+    metadata: extractClipMetadata(document, location.href),
+    selectionPresent,
+  }
+}
+
+function articleHtml() {
+  const article =
+    document.querySelector("article") ??
+    document.querySelector("main") ??
+    document.querySelector('[role="main"]') ??
+    document.body
+  return article?.innerHTML ?? ""
+}
+
+function fragmentHtml(fragment: DocumentFragment) {
+  const container = document.createElement("div")
+  container.append(fragment)
+  return container.innerHTML
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+}

--- a/apps/clipper/entrypoints/options/app.tsx
+++ b/apps/clipper/entrypoints/options/app.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react"
+import { browser } from "wxt/browser"
+
+import { Button } from "@/shared/ui/button"
+import {
+  Field,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+} from "@/shared/ui/field"
+import { Input } from "@/shared/ui/input"
+import {
+  clearSession,
+  readSession,
+  writeSession,
+} from "../../lib/session"
+
+export function OptionsApp() {
+  const [instanceUrl, setInstanceUrl] = useState("")
+  const [workspaceId, setWorkspaceId] = useState("")
+  const [workspaceName, setWorkspaceName] = useState("")
+  const [token, setToken] = useState("")
+  const [status, setStatus] = useState<string | null>(null)
+
+  useEffect(() => {
+    void (async () => {
+      const pending = await browser.storage.local.get("clipper.pendingInstanceUrl")
+      const session = await readSession()
+      setInstanceUrl(
+        session?.instanceUrl ??
+          (pending["clipper.pendingInstanceUrl"] as string | undefined) ??
+          "",
+      )
+      if (!session) return
+      setWorkspaceId(session.workspaceId)
+      setWorkspaceName(session.workspaceName)
+    })()
+  }, [])
+
+  const save = async () => {
+    await writeSession({
+      instanceUrl: instanceUrl.trim().replace(/\/$/, ""),
+      workspaceId: workspaceId.trim(),
+      workspaceName: workspaceName.trim() || "Workspace",
+      token: token.trim(),
+    })
+    setToken("")
+    setStatus("Connected. You can close this tab.")
+  }
+
+  const disconnect = async () => {
+    await clearSession()
+    setToken("")
+    setStatus("Disconnected.")
+  }
+
+  return (
+    <main className="min-h-svh bg-surface-canvas px-4 py-8 text-content-primary">
+      <div className="mx-auto grid w-full max-w-3xl gap-6">
+        <div className="flex flex-col">
+          <h1 className="text-xl font-semibold tracking-normal">Web Clipper</h1>
+          <p className="text-sm text-content-secondary">
+            Connect a workspace-scoped API key from Zilobase Settings.
+          </p>
+        </div>
+        <section className="grid gap-4">
+          <FieldGroup>
+            <Field>
+              <FieldLabel>Server URL</FieldLabel>
+              <Input
+                onChange={(event) => setInstanceUrl(event.target.value)}
+                placeholder="https://app.example.com"
+                value={instanceUrl}
+              />
+            </Field>
+            <Field>
+              <FieldLabel>Workspace ID</FieldLabel>
+              <Input
+                onChange={(event) => setWorkspaceId(event.target.value)}
+                value={workspaceId}
+              />
+            </Field>
+            <Field>
+              <FieldLabel>Workspace name</FieldLabel>
+              <Input
+                onChange={(event) => setWorkspaceName(event.target.value)}
+                value={workspaceName}
+              />
+            </Field>
+            <Field>
+              <FieldLabel>API key</FieldLabel>
+              <Input
+                onChange={(event) => setToken(event.target.value)}
+                placeholder="nl_…"
+                type="password"
+                value={token}
+              />
+              <FieldDescription>
+                Create a key in Settings → API Keys. It is stored only in this
+                browser.
+              </FieldDescription>
+            </Field>
+          </FieldGroup>
+          <div className="flex gap-2">
+            <Button onClick={() => void save()}>Save connection</Button>
+            <Button onClick={() => void disconnect()} variant="outline">
+              Disconnect
+            </Button>
+          </div>
+          {status ? (
+            <p className="text-sm text-content-secondary">{status}</p>
+          ) : null}
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/apps/clipper/entrypoints/options/index.html
+++ b/apps/clipper/entrypoints/options/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Zilobase Web Clipper</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/clipper/entrypoints/options/main.tsx
+++ b/apps/clipper/entrypoints/options/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+
+import "../../assets/clipper.css"
+import { OptionsApp } from "./app"
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <OptionsApp />
+  </StrictMode>,
+)

--- a/apps/clipper/entrypoints/popup/app.tsx
+++ b/apps/clipper/entrypoints/popup/app.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useState } from "react"
+import { browser } from "wxt/browser"
+import type { ClipCaptureMode } from "@zilobase/features/clips"
+
+import { Bookmark, SettingsIcon } from "@/shared/components/icons"
+import { Button } from "@/shared/ui/button"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/shared/ui/empty"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@/shared/ui/field"
+import { Input } from "@/shared/ui/input"
+import { Spinner } from "@/shared/ui/spinner"
+import { createClip, openClippedPage } from "../../lib/api"
+import type { ExtractResult } from "../../lib/messages"
+import {
+  readLastDestination,
+  readSession,
+  writeLastDestination,
+  type ClipperDestination,
+  type ClipperSession,
+} from "../../lib/session"
+
+const captureModes: Array<{ label: string; value: ClipCaptureMode }> = [
+  { label: "Article", value: "article" },
+  { label: "Selection", value: "selection" },
+  { label: "Page", value: "page" },
+  { label: "Bookmark", value: "bookmark" },
+]
+
+export function PopupApp() {
+  const [session, setSession] = useState<ClipperSession | null>(null)
+  const [instanceUrl, setInstanceUrl] = useState("")
+  const [title, setTitle] = useState("")
+  const [captureMode, setCaptureMode] = useState<ClipCaptureMode>("article")
+  const [extracted, setExtracted] = useState<ExtractResult | null>(null)
+  const [destination, setDestination] = useState<ClipperDestination | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [savedUrl, setSavedUrl] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    void (async () => {
+      const current = await readSession()
+      setSession(current)
+      if (current) setInstanceUrl(current.instanceUrl)
+      setDestination(await readLastDestination())
+      setReady(true)
+    })()
+  }, [])
+
+  useEffect(() => {
+    if (!session) return
+    void extract(captureMode)
+  }, [session, captureMode])
+
+  const extract = async (mode: ClipCaptureMode) => {
+    const [tab] = await browser.tabs.query({ active: true, currentWindow: true })
+    if (!tab?.id) return
+    try {
+      const result = (await browser.tabs.sendMessage(tab.id, {
+        type: "EXTRACT",
+        captureMode: mode,
+      })) as ExtractResult
+      setExtracted(result)
+      setTitle(result.metadata.title)
+    } catch {
+      setError("Reload this tab, then open the clipper again.")
+    }
+  }
+
+  const connect = async () => {
+    const origin = instanceUrl.trim().replace(/\/$/, "")
+    if (!origin) {
+      setError("Enter your Zilobase server URL.")
+      return
+    }
+    setError(null)
+    await browser.storage.local.set({
+      "clipper.pendingInstanceUrl": origin,
+    })
+    await browser.runtime.openOptionsPage()
+  }
+
+  const save = async () => {
+    if (!session || !extracted) return
+    setSaving(true)
+    setError(null)
+    try {
+      const result = await createClip(session, {
+        workspaceId: session.workspaceId,
+        title: title.trim() || extracted.metadata.title,
+        sourceUrl: extracted.metadata.url,
+        canonicalUrl: extracted.metadata.canonicalUrl,
+        captureMode,
+        html: captureMode === "bookmark" ? null : extracted.html,
+        parentPageId: destination?.kind === "page" ? destination.id : null,
+        databaseId: destination?.kind === "database" ? destination.id : null,
+        metadata: {
+          author: extracted.metadata.author,
+          description: extracted.metadata.description,
+          favicon: extracted.metadata.favicon,
+          image: extracted.metadata.image,
+          published: extracted.metadata.published,
+          site: extracted.metadata.site,
+        },
+      })
+      if (destination) await writeLastDestination(destination)
+      setSavedUrl(result.url)
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Save failed")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!ready) {
+    return (
+      <div className="flex h-40 items-center justify-center bg-surface-overlay">
+        <Spinner />
+      </div>
+    )
+  }
+
+  if (!session?.token) {
+    return (
+      <div className="bg-surface-overlay p-4 text-content-primary">
+        <Empty className="rounded-xl border-0 p-6">
+          <EmptyHeader>
+            <EmptyMedia>
+              <Bookmark className="size-6" />
+            </EmptyMedia>
+            <EmptyTitle>Connect Zilobase</EmptyTitle>
+            <EmptyDescription>
+              Sign in on your instance so the clipper can save pages.
+            </EmptyDescription>
+          </EmptyHeader>
+          <FieldGroup className="w-full gap-3">
+            <Field>
+              <FieldLabel>Server URL</FieldLabel>
+              <Input
+                onChange={(event) => setInstanceUrl(event.target.value)}
+                placeholder="https://app.example.com"
+                value={instanceUrl}
+              />
+            </Field>
+            {error ? <FieldError>{error}</FieldError> : null}
+            <Button className="w-full" onClick={() => void connect()}>
+              Connect
+            </Button>
+          </FieldGroup>
+        </Empty>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4 bg-surface-overlay p-4 text-xs/relaxed text-content-primary">
+      <header className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Bookmark className="size-4" />
+          <h1 className="font-heading text-sm font-medium">Save to Zilobase</h1>
+        </div>
+        <Button
+          onClick={() => void browser.runtime.openOptionsPage()}
+          size="icon-sm"
+          variant="ghost"
+        >
+          <SettingsIcon />
+        </Button>
+      </header>
+
+      <FieldGroup className="gap-3">
+        <Field>
+          <FieldLabel>Title</FieldLabel>
+          <Input onChange={(event) => setTitle(event.target.value)} value={title} />
+        </Field>
+        <Field>
+          <FieldLabel>Workspace</FieldLabel>
+          <Input disabled value={session.workspaceName} />
+        </Field>
+        <Field>
+          <FieldLabel>Capture</FieldLabel>
+          <div className="grid grid-cols-4 gap-1">
+            {captureModes.map((mode) => (
+              <Button
+                aria-pressed={captureMode === mode.value}
+                disabled={mode.value === "selection" && !extracted?.selectionPresent}
+                key={mode.value}
+                onClick={() => setCaptureMode(mode.value)}
+                size="sm"
+                variant={captureMode === mode.value ? "secondary" : "outline"}
+              >
+                {mode.label}
+              </Button>
+            ))}
+          </div>
+        </Field>
+      </FieldGroup>
+
+      {error ? <FieldError>{error}</FieldError> : null}
+
+      {savedUrl && session ? (
+        <Button
+          onClick={() => openClippedPage(session, savedUrl)}
+          variant="link"
+        >
+          Open in Zilobase
+        </Button>
+      ) : (
+        <div className="flex justify-end gap-2">
+          <Button onClick={() => window.close()} variant="outline">
+            Cancel
+          </Button>
+          <Button disabled={saving} onClick={() => void save()}>
+            {saving ? <Spinner /> : null}
+            {saving ? "Saving..." : "Save page"}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/clipper/entrypoints/popup/index.html
+++ b/apps/clipper/entrypoints/popup/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en" data-clipper-popup>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Save to Zilobase</title>
+    <meta name="manifest.type" content="browser_action" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/clipper/entrypoints/popup/main.tsx
+++ b/apps/clipper/entrypoints/popup/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+
+import "../../assets/clipper.css"
+import { PopupApp } from "./app"
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <PopupApp />
+  </StrictMode>,
+)

--- a/apps/clipper/lib/api.ts
+++ b/apps/clipper/lib/api.ts
@@ -1,0 +1,36 @@
+import { browser } from "wxt/browser"
+import type {
+  CreateClipRequest,
+  CreateClipResponse,
+} from "@zilobase/features/clips"
+
+import type { ClipperSession } from "./session"
+
+export async function createClip(
+  session: ClipperSession,
+  body: CreateClipRequest,
+) {
+  const response = await fetch(new URL("/clips", session.instanceUrl), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`,
+      "Content-Type": "application/json",
+      "x-zilobase-workspace-id": session.workspaceId,
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as {
+      error?: string
+    } | null
+    throw new Error(payload?.error ?? `Save failed (${response.status})`)
+  }
+
+  return (await response.json()) as CreateClipResponse
+}
+
+export function openClippedPage(session: ClipperSession, path: string) {
+  const url = new URL(path, session.instanceUrl)
+  void browser.tabs.create({ url: url.toString() })
+}

--- a/apps/clipper/lib/messages.ts
+++ b/apps/clipper/lib/messages.ts
@@ -1,0 +1,21 @@
+import type { ClipCaptureMode } from "@zilobase/features/clips"
+import type { ClipMetadata } from "@zilobase/html-to-page/extract-clip-metadata"
+
+export type ExtractResult = {
+  html: string
+  metadata: ClipMetadata
+  selectionPresent: boolean
+}
+
+export type ExtractMessage = {
+  type: "EXTRACT"
+  captureMode: ClipCaptureMode
+}
+
+export function isExtractMessage(value: unknown): value is ExtractMessage {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      (value as ExtractMessage).type === "EXTRACT",
+  )
+}

--- a/apps/clipper/lib/session.ts
+++ b/apps/clipper/lib/session.ts
@@ -1,0 +1,39 @@
+import { browser } from "wxt/browser"
+
+export type ClipperSession = {
+  instanceUrl: string
+  token: string
+  workspaceId: string
+  workspaceName: string
+}
+
+export type ClipperDestination = {
+  id: string
+  kind: "page" | "database"
+  title: string
+}
+
+const sessionKey = "clipper.session"
+const destinationKey = "clipper.destination"
+
+export async function readSession() {
+  const stored = await browser.storage.local.get(sessionKey)
+  return (stored[sessionKey] as ClipperSession | undefined) ?? null
+}
+
+export async function writeSession(session: ClipperSession) {
+  await browser.storage.local.set({ [sessionKey]: session })
+}
+
+export async function clearSession() {
+  await browser.storage.local.remove(sessionKey)
+}
+
+export async function readLastDestination() {
+  const stored = await browser.storage.local.get(destinationKey)
+  return (stored[destinationKey] as ClipperDestination | undefined) ?? null
+}
+
+export async function writeLastDestination(destination: ClipperDestination) {
+  await browser.storage.local.set({ [destinationKey]: destination })
+}

--- a/apps/clipper/package.json
+++ b/apps/clipper/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@zilobase/clipper",
+  "version": "0.0.55",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "dev": "wxt",
+    "dev:firefox": "wxt -b firefox",
+    "build": "wxt build",
+    "build:firefox": "wxt build -b firefox",
+    "zip": "wxt zip",
+    "zip:firefox": "wxt zip -b firefox",
+    "postinstall": "wxt prepare",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@phosphor-icons/react": "^2.1.10",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "radix-ui": "^1.4.3",
+    "tailwind-merge": "^3.6.0",
+    "@zilobase/features": "file:../../packages/features",
+    "@zilobase/html-to-page": "file:../../packages/html-to-page"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.3.0",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@wxt-dev/module-react": "^1.2.0",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
+    "tailwindcss": "^4.3.0",
+    "typescript": "^5.9.3",
+    "wxt": "^0.20.11"
+  }
+}

--- a/apps/clipper/tsconfig.json
+++ b/apps/clipper/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "jsx": "react-jsx",
+    "types": ["node"],
+    "paths": {
+      "@/shared/*": ["../web/src/shared/*"]
+    }
+  },
+  "include": ["entrypoints", "lib", "components", "wxt.config.ts", "wxt-env.d.ts"]
+}

--- a/apps/clipper/wxt-env.d.ts
+++ b/apps/clipper/wxt-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="wxt/client" />

--- a/apps/clipper/wxt.config.ts
+++ b/apps/clipper/wxt.config.ts
@@ -1,0 +1,47 @@
+import path from "node:path"
+import tailwindcss from "@tailwindcss/vite"
+import { defineConfig } from "wxt"
+
+export default defineConfig({
+  modules: ["@wxt-dev/module-react"],
+  srcDir: ".",
+  outDir: ".output",
+  imports: false,
+  // Keep WXT's HMR server off the Node API (3000), health (3001), and Worker API (3010).
+  dev: {
+    server: {
+      port: 3400,
+      strictPort: true,
+    },
+  },
+  manifest: {
+    name: "Zilobase Web Clipper",
+    description: "Save web pages to Zilobase",
+    permissions: ["activeTab", "contextMenus", "storage", "scripting"],
+    host_permissions: ["<all_urls>"],
+    commands: {
+      "open-clipper": {
+        description: "Open clipper",
+        suggested_key: {
+          default: "Ctrl+Shift+S",
+          mac: "Command+Shift+S",
+        },
+      },
+      "quick-clip": {
+        description: "Quick clip to last destination",
+        suggested_key: {
+          default: "Alt+Shift+S",
+          mac: "Alt+Shift+S",
+        },
+      },
+    },
+  },
+  vite: () => ({
+    plugins: [tailwindcss()],
+    resolve: {
+      alias: {
+        "@/shared": path.resolve(__dirname, "../web/src/shared"),
+      },
+    },
+  }),
+})

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -63,6 +63,7 @@
     "@opentelemetry/sdk-node": "^0.221.0",
     "@tiptap/pm": "^3.23.6",
     "@zilobase/features": "file:../../packages/features",
+    "@zilobase/html-to-page": "file:../../packages/html-to-page",
     "@zilobase/page-context": "file:../../packages/page-context",
     "ai": "^6.0.193",
     "better-auth": "^1.6.25",

--- a/apps/server/src/app/routes.ts
+++ b/apps/server/src/app/routes.ts
@@ -3,6 +3,7 @@ import type { Hono } from "hono";
 
 import { aiAgentProfileRoutes, aiAgentWebhookRoutes, aiMcpRoutes, aiRoutes, aiThreadRoutes } from "../features/ai/routes";
 import { apiKeyRoutes } from "../features/api-keys/routes";
+import { clipRoutes } from "../features/clips";
 import { authRoutes } from "../features/auth/routes";
 import { sessionRoutes } from "../features/auth/session-routes";
 import { databaseRoutes } from "../features/databases/database-routes";
@@ -36,6 +37,7 @@ export function registerRoutes(app: Hono<AppBindings>) {
   app.route("/api/ai", aiAgentWebhookRoutes);
   app.route("/api/ai", aiMcpRoutes);
   app.route("/api/keys", apiKeyRoutes);
+  app.route("/clips", clipRoutes);
   app.route("/", desktopAuthRoutes);
   app.route("/", authRoutes);
   app.route("/databases", databaseRoutes);

--- a/apps/server/src/features/clips/build-clip-content.test.ts
+++ b/apps/server/src/features/clips/build-clip-content.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict"
+import { test } from "vitest"
+
+import { installDomParser } from "@zilobase/html-to-page"
+import { buildClipContent } from "./build-clip-content"
+
+installDomParser()
+
+test("buildClipContent converts html and prepends a bookmark", () => {
+  const document = buildClipContent({
+    workspaceId: "workspace-1",
+    title: "Article",
+    sourceUrl: "https://example.com/post",
+    captureMode: "article",
+    html: "<h1>Hello</h1><p>Body</p>",
+    metadata: { description: "Desc" },
+  })
+
+  assert.equal(document.content[0]?.type, "bookmarkBlock")
+  assert.equal(document.content[0]?.attrs?.href, "https://example.com/post")
+  assert.ok(document.content.some((node) => node.type === "heading"))
+})
+
+test("buildClipContent drops javascript urls from submitted json", () => {
+  const document = buildClipContent({
+    workspaceId: "workspace-1",
+    title: "Unsafe",
+    sourceUrl: "https://example.com/post",
+    captureMode: "article",
+    content: {
+      type: "doc",
+      content: [
+        {
+          type: "imageBlock",
+          attrs: { src: "javascript:alert(1)" },
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "ok" }],
+        },
+      ],
+    },
+  })
+
+  assert.equal(
+    document.content.some((node) => node.type === "imageBlock"),
+    false,
+  )
+  assert.ok(document.content.some((node) => node.type === "paragraph"))
+})

--- a/apps/server/src/features/clips/build-clip-content.ts
+++ b/apps/server/src/features/clips/build-clip-content.ts
@@ -1,0 +1,37 @@
+import {
+  assembleClipDocument,
+  ensureDomParser,
+  htmlToPageContent,
+  sanitizePageContent,
+  type PageDocument,
+} from "@zilobase/html-to-page"
+import type { CreateClipRequest } from "@zilobase/features/clips"
+
+export function buildClipContent(input: CreateClipRequest): PageDocument {
+  ensureDomParser()
+
+  const converted = input.html
+    ? htmlToPageContent(input.html)
+    : isPageDocument(input.content)
+      ? sanitizePageContent(input.content)
+      : { type: "doc" as const, content: [{ type: "paragraph" }] }
+
+  return assembleClipDocument({
+    sourceUrl: input.sourceUrl,
+    title: input.title,
+    description: input.metadata?.description ?? null,
+    favicon: input.metadata?.favicon ?? null,
+    image: input.metadata?.image ?? null,
+    note: input.note ?? null,
+    content: converted,
+  })
+}
+
+function isPageDocument(value: unknown): value is PageDocument {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      (value as PageDocument).type === "doc" &&
+      Array.isArray((value as PageDocument).content),
+  )
+}

--- a/apps/server/src/features/clips/create-clip-service.ts
+++ b/apps/server/src/features/clips/create-clip-service.ts
@@ -1,0 +1,164 @@
+import { and, eq, isNull, sql } from "drizzle-orm"
+import type { CreateClipRequest, CreateClipResponse } from "@zilobase/features/clips"
+
+import {
+  canAccessDatabaseInWorkspace,
+  canAccessPage,
+  getMembership,
+} from "../access"
+import { createDatabaseRowService } from "../databases/rows/service"
+import { getDataSourceRecord } from "../databases/access/data-source-access"
+import { db } from "../../infrastructure/database"
+import { dataSource, page } from "../../infrastructure/database/schema"
+import { ServiceMutationError } from "../../shared/errors/service-mutation-error"
+import type { RuntimeEnv } from "../../shared/config/config"
+import { createPageService } from "../pages/mutations/page-mutations"
+import { buildClipContent } from "./build-clip-content"
+
+export async function createClipService(input: {
+  request: CreateClipRequest
+  userId: string
+  env?: RuntimeEnv
+}): Promise<CreateClipResponse> {
+  const { request, userId, env } = input
+  const sourceUrl = request.canonicalUrl?.trim() || request.sourceUrl
+  const duplicateStrategy = request.duplicateStrategy ?? "create"
+
+  if (request.parentPageId) {
+    if (!(await canAccessPage(request.parentPageId, userId, "edit"))) {
+      throw new ServiceMutationError("Forbidden", 403)
+    }
+  } else if (!(await getMembership(request.workspaceId, userId))) {
+    throw new ServiceMutationError("Forbidden", 403)
+  }
+
+  if (request.databaseId) {
+    if (
+      !(await canAccessDatabaseInWorkspace(
+        request.databaseId,
+        request.workspaceId,
+        userId,
+        "edit",
+      ))
+    ) {
+      throw new ServiceMutationError("Forbidden", 403)
+    }
+  }
+
+  const existing = await findDuplicateClip({
+    sourceUrl,
+    userId,
+    workspaceId: request.workspaceId,
+  })
+
+  if (existing && duplicateStrategy === "reject") {
+    throw new ServiceMutationError("This URL has already been clipped.", 409)
+  }
+
+  if (existing && duplicateStrategy === "open-existing") {
+    return {
+      pageId: existing.pageId,
+      url: `/p/${existing.pageId}`,
+      duplicateOf: existing.pageId,
+    }
+  }
+
+  const content = buildClipContent(request)
+  const metadata = {
+    cover: request.metadata?.image ?? null,
+    clip: {
+      capturedAt: new Date().toISOString(),
+      captureMode: request.captureMode,
+      canonicalUrl: request.canonicalUrl ?? null,
+      sourceUrl,
+    },
+  }
+
+  const created = await createPageService({
+    content,
+    env,
+    metadata,
+    name: request.title,
+    parentPageId: request.parentPageId ?? undefined,
+    userId,
+    workspaceId: request.workspaceId,
+  })
+
+  let databaseRowId: string | undefined
+
+  if (request.databaseId) {
+    const dataSourceId = await resolveDataSourceId(request.databaseId)
+    const row = await createDatabaseRowService({
+      databaseId: dataSourceId,
+      env,
+      initialValues: request.propertyValues,
+      origin: "api",
+      pageId: created.pageId,
+      parentRowId: null,
+      sourceDataSourceId: null,
+      sourcePropertyMode: "match",
+      sourceRowId: null,
+      title: request.title,
+      userId,
+    })
+    databaseRowId = row.rowId
+  }
+
+  return {
+    pageId: created.pageId,
+    databaseRowId,
+    url: `/p/${created.pageId}`,
+  }
+}
+
+async function resolveDataSourceId(databaseOrSourceId: string) {
+  const exact = await getDataSourceRecord(databaseOrSourceId)
+  if (exact) return exact.id
+
+  const [source] = await db
+    .select({ id: dataSource.id })
+    .from(dataSource)
+    .where(
+      and(
+        eq(dataSource.parentDatabaseId, databaseOrSourceId),
+        isNull(dataSource.deletedAt),
+      ),
+    )
+    .limit(1)
+
+  if (!source) {
+    throw new ServiceMutationError("Data source not found", 404)
+  }
+
+  return source.id
+}
+
+export async function findDuplicateClip(input: {
+  sourceUrl: string
+  userId: string
+  workspaceId: string
+}) {
+  const matches = await db
+    .select({
+      id: page.id,
+      name: page.name,
+      workspaceId: page.workspaceId,
+    })
+    .from(page)
+    .where(
+      and(
+        eq(page.workspaceId, input.workspaceId),
+        isNull(page.deletedAt),
+        sql`${page.metadata} -> 'clip' ->> 'sourceUrl' = ${input.sourceUrl}`,
+      ),
+    )
+    .limit(8)
+
+  for (const record of matches) {
+    if (await canAccessPage(record.id, input.userId, "view")) {
+      return { pageId: record.id, title: record.name }
+    }
+  }
+
+  return null
+}

--- a/apps/server/src/features/clips/index.ts
+++ b/apps/server/src/features/clips/index.ts
@@ -1,0 +1,2 @@
+export { clipRoutes } from "./routes"
+export { createClipService, findDuplicateClip } from "./create-clip-service"

--- a/apps/server/src/features/clips/routes.ts
+++ b/apps/server/src/features/clips/routes.ts
@@ -1,0 +1,140 @@
+import { Hono } from "hono"
+import {
+  isClipCaptureMode,
+  isClipDuplicateStrategy,
+  type CreateClipRequest,
+} from "@zilobase/features/clips"
+
+import { rejectMismatchedApiKeyWorkspace } from "../api-keys"
+import { getAuthenticatedUser, readAuthenticatedJson } from "../../shared/http/auth"
+import type { AppBindings } from "../../shared/types"
+import { ServiceMutationError } from "../../shared/errors/service-mutation-error"
+import { createClipService, findDuplicateClip } from "./create-clip-service"
+
+export const clipRoutes = new Hono<AppBindings>()
+
+clipRoutes.post("/", async (c) => {
+  const request = await readAuthenticatedJson(c)
+  if (!request.ok) return request.response
+  const parsed = parseCreateClipRequest(request.body as Record<string, unknown>)
+  if (!parsed.ok) {
+    return c.json({ error: parsed.error }, 400)
+  }
+
+  const mismatch = rejectMismatchedApiKeyWorkspace(c, parsed.value.workspaceId)
+  if (mismatch) return mismatch
+
+  try {
+    const result = await createClipService({
+      env: c.env,
+      request: parsed.value,
+      userId: request.user.id,
+    })
+    return c.json(result, result.duplicateOf ? 200 : 201)
+  } catch (error) {
+    if (error instanceof ServiceMutationError) {
+      return c.json({ error: error.message }, error.status as 400 | 403 | 409)
+    }
+    throw error
+  }
+})
+
+clipRoutes.get("/duplicates", async (c) => {
+  const user = getAuthenticatedUser(c)
+  if (!user) return c.json({ error: "Unauthorized" }, 401)
+
+  const workspaceId = c.req.query("workspaceId")?.trim()
+  const url = c.req.query("url")?.trim()
+  if (!workspaceId || !url) {
+    return c.json({ error: "workspaceId and url are required" }, 400)
+  }
+
+  const mismatch = rejectMismatchedApiKeyWorkspace(c, workspaceId)
+  if (mismatch) return mismatch
+
+  const duplicate = await findDuplicateClip({
+    sourceUrl: url,
+    userId: user.id,
+    workspaceId,
+  })
+
+  if (!duplicate) {
+    return c.json({ duplicate: null })
+  }
+
+  return c.json({
+    duplicate: {
+      pageId: duplicate.pageId,
+      title: duplicate.title,
+      url: `/p/${duplicate.pageId}`,
+    },
+  })
+})
+
+function parseCreateClipRequest(
+  body: Record<string, unknown>,
+): { ok: true; value: CreateClipRequest } | { ok: false; error: string } {
+  const workspaceId = body.workspaceId
+  const title = body.title
+  const sourceUrl = body.sourceUrl
+  const captureMode = body.captureMode
+
+  if (typeof workspaceId !== "string" || workspaceId.length === 0) {
+    return { ok: false, error: "workspaceId is required" }
+  }
+  if (typeof title !== "string" || title.trim().length === 0) {
+    return { ok: false, error: "title is required" }
+  }
+  if (typeof sourceUrl !== "string" || !/^https?:\/\//i.test(sourceUrl)) {
+    return { ok: false, error: "sourceUrl must be an http(s) URL" }
+  }
+  if (!isClipCaptureMode(captureMode)) {
+    return { ok: false, error: "captureMode is invalid" }
+  }
+  if (
+    body.parentPageId != null &&
+    typeof body.parentPageId !== "string"
+  ) {
+    return { ok: false, error: "parentPageId must be a string or null" }
+  }
+  if (body.databaseId != null && typeof body.databaseId !== "string") {
+    return { ok: false, error: "databaseId must be a string or null" }
+  }
+  if (
+    body.duplicateStrategy != null &&
+    !isClipDuplicateStrategy(body.duplicateStrategy)
+  ) {
+    return { ok: false, error: "duplicateStrategy is invalid" }
+  }
+  if (body.html != null && typeof body.html !== "string") {
+    return { ok: false, error: "html must be a string" }
+  }
+  if (body.note != null && typeof body.note !== "string") {
+    return { ok: false, error: "note must be a string" }
+  }
+
+  return {
+    ok: true,
+    value: {
+      workspaceId,
+      title: title.trim(),
+      sourceUrl,
+      captureMode,
+      parentPageId: (body.parentPageId as string | null | undefined) ?? null,
+      databaseId: (body.databaseId as string | null | undefined) ?? null,
+      teamspaceId: typeof body.teamspaceId === "string" ? body.teamspaceId : null,
+      canonicalUrl:
+        typeof body.canonicalUrl === "string" ? body.canonicalUrl : null,
+      note: typeof body.note === "string" ? body.note : null,
+      html: typeof body.html === "string" ? body.html : null,
+      content: body.content ?? null,
+      metadata:
+        body.metadata && typeof body.metadata === "object"
+          ? (body.metadata as CreateClipRequest["metadata"])
+          : undefined,
+      duplicateStrategy: isClipDuplicateStrategy(body.duplicateStrategy)
+        ? body.duplicateStrategy
+        : "create",
+    },
+  }
+}

--- a/apps/server/src/shared/config/config.test.ts
+++ b/apps/server/src/shared/config/config.test.ts
@@ -164,6 +164,22 @@ test("allowed origins include configured clients and local Expo development", ()
   assert.equal(isAllowedClientOrigin(env, "https://localhost"), false);
 });
 
+test("clipper extension origins are allowed when configured", () => {
+  const env = {
+    CLIENT_URL: "https://app.example.com",
+    CLIPPER_EXTENSION_ORIGINS: "chrome-extension://abcdefghijklmnop",
+  };
+
+  assert.equal(
+    isAllowedClientOrigin(env, "chrome-extension://abcdefghijklmnop"),
+    true,
+  );
+  assert.equal(
+    isAllowedClientOrigin(env, "chrome-extension://attacker"),
+    false,
+  );
+});
+
 test("trusted origins add development clients only for local requests", () => {
   const env = {
     CLIENT_URL: "https://app.example.com,https://app.example.com",

--- a/apps/server/src/shared/config/config.ts
+++ b/apps/server/src/shared/config/config.ts
@@ -64,6 +64,32 @@ export function getClientOrigins(env: RuntimeEnv) {
     .filter(Boolean);
 }
 
+const clipperOriginSchemes = [
+  "chrome-extension:",
+  "moz-extension:",
+  "safari-web-extension:",
+] as const
+
+export function getClipperExtensionOrigins(env: RuntimeEnv) {
+  return (getStringEnv(env, "CLIPPER_EXTENSION_ORIGINS") ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => {
+      const url = parseUrl(origin)
+      return Boolean(
+        url &&
+          clipperOriginSchemes.includes(
+            url.protocol as (typeof clipperOriginSchemes)[number],
+          ) &&
+          (url.pathname === "/" || url.pathname === "") &&
+          !url.username &&
+          !url.password &&
+          !url.search &&
+          !url.hash,
+      )
+    })
+}
+
 export function getPrimaryClientOrigin(env: RuntimeEnv) {
   const [origin] = getClientOrigins(env);
 
@@ -198,6 +224,7 @@ export function isAllowedClientOrigin(env: RuntimeEnv, origin: string | null) {
 
   if (
     getClientOrigins(env).includes(origin) ||
+    getClipperExtensionOrigins(env).includes(origin) ||
     DESKTOP_CLIENT_ORIGINS.includes(
       origin as (typeof DESKTOP_CLIENT_ORIGINS)[number],
     )
@@ -235,6 +262,7 @@ export function getTrustedOrigins(env: RuntimeEnv, requestOrigin: string) {
       requestOrigin,
       ...readCanonicalApiOrigin(env),
       ...getClientOrigins(env),
+      ...getClipperExtensionOrigins(env),
       ...DESKTOP_CLIENT_ORIGINS,
       "mobile://",
       "mobile://*",

--- a/apps/web/src/shared/config/feature-flags.ts
+++ b/apps/web/src/shared/config/feature-flags.ts
@@ -37,6 +37,10 @@ export const appConfig = {
       import.meta.env.VITE_FEATURE_NOTION_IMPORT,
       false,
     ),
+    webClipper: readBooleanFeatureFlag(
+      import.meta.env.VITE_FEATURE_WEB_CLIPPER,
+      false,
+    ),
     teamspaces: readBooleanFeatureFlag(
       import.meta.env.VITE_FEATURE_TEAMSPACES,
       true,

--- a/architecture/README.md
+++ b/architecture/README.md
@@ -31,6 +31,7 @@ Each guide follows a capability through its web, shared-package, server and nati
 - [User settings](features/settings/README.md)
 - [Canvas](features/canvas/README.md)
 - [Notion import](features/notion-import/README.md)
+- [Clips](features/clips/README.md)
 - [Offline documents](features/offline/README.md)
 - [Desktop integration](features/desktop/README.md)
 - [Hosted demo](features/demo/README.md)

--- a/architecture/features/clips/README.md
+++ b/architecture/features/clips/README.md
@@ -1,0 +1,27 @@
+# Clips
+
+## Owning modules and interface
+
+- [apps/server/src/features/clips](../../../apps/server/src/features/clips)
+- [packages/features/src/clips](../../../packages/features/src/clips)
+- [packages/html-to-page](../../../packages/html-to-page/src)
+
+## Main flow
+
+The Web Clipper posts sanitized HTML (or Tiptap JSON) to `POST /clips`. The [clip content builder](../../../apps/server/src/features/clips/build-clip-content.ts) converts HTML through `@zilobase/html-to-page`, prepends a bookmark block, and the [create service](../../../apps/server/src/features/clips/create-clip-service.ts) persists a page via `createPageService`. Optional `databaseId` may be a parent database id (as returned by search) or a data-source id; the service resolves the active data source before `createDatabaseRowService`. Duplicate URLs are stored on `page.metadata.clip.sourceUrl` and queried by `GET /clips/duplicates`.
+
+Browser extension origins are allowlisted through `CLIPPER_EXTENSION_ORIGINS` (chrome-extension, moz-extension, safari-web-extension). API-key callers must match their pinned workspace.
+
+## Authorization and persistence
+
+Clips use the same page and database access checks as in-app create. API keys remain workspace-scoped. Source HTML is not trusted application markup; conversion sanitizes scripts, `javascript:` URLs, and unknown embeds before persistence.
+
+## Side effects, failures and recovery
+
+Creating a clip writes a page, a collaboration document, optional database row, and a navigation invalidation. Duplicate strategy `reject` returns 409; `open-existing` returns the prior page without a write. Image rehost happens after create from the extension, not in this request.
+
+## Verification and change points
+
+Start with [clip content tests](../../../apps/server/src/features/clips/build-clip-content.test.ts) and [html-to-page tests](../../../packages/html-to-page/src/html-to-page-content.test.ts). Run the affected workspace scripts in [testing and quality](../../setup/testing-and-quality.md).
+
+Update this guide when ownership, interfaces, authorization, persistence or cross-module flows change. [Architecture index](../../README.md).

--- a/architecture/platform/shared-packages.md
+++ b/architecture/platform/shared-packages.md
@@ -2,9 +2,9 @@
 
 ## Interface and flow
 
-Shared feature modules contain contracts, pure transformations, client queries and React bindings. Page-context supplies structural page/markdown conversion; the splitter and comment extension retain focused editor responsibilities.
+Shared feature modules contain contracts, pure transformations, client queries and React bindings. Page-context supplies structural page/markdown conversion; html-to-page converts sanitized webpage HTML into Tiptap JSON for clips; the splitter and comment extension retain focused editor responsibilities.
 
-Start at the [entrypoint](../../packages/features/package.json); follow the [implementation](../../packages/features/src) and [related modules](../../packages/page-context/src).
+Start at the [entrypoint](../../packages/features/package.json); follow the [implementation](../../packages/features/src), [page-context](../../packages/page-context/src) and [html-to-page](../../packages/html-to-page/src).
 
 ## Invariants and failure handling
 

--- a/architecture/repository-map.md
+++ b/architecture/repository-map.md
@@ -14,6 +14,7 @@
 | Native host | Authentication, server selection, recording and diagnostics | [Rust modules](../apps/desktop/src-tauri/src) |
 | Shared features | Contracts, pure rules, queries and React bindings | [features package](../packages/features/src) |
 | Page context | Structural page content and markdown conversion | [page-context](../packages/page-context/src) |
+| HTML to page | Webpage HTML sanitization and Tiptap JSON conversion for clips | [html-to-page](../packages/html-to-page/src) |
 | Editor utilities | Markdown splitting and comment extension | [splitter](../packages/markdown-text-splitter), [comments](../packages/tiptap-comment-extension) |
 | Setup and operations | Development, deployment and release tooling | [scripts](../scripts), [deploy](../deploy), [docker](../docker) |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "workspaces": [
         "apps/*",
         "packages/features",
+        "packages/html-to-page",
         "packages/markdown-text-splitter",
         "packages/page-context",
         "packages/tiptap-comment-extension"
@@ -24,6 +25,46 @@
         "typescript": "6.0.3",
         "webdriverio": "^9.30.1",
         "ws": "^8.21.0"
+      }
+    },
+    "apps/clipper": {
+      "name": "@zilobase/clipper",
+      "version": "0.0.55",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phosphor-icons/react": "^2.1.10",
+        "@zilobase/features": "file:../../packages/features",
+        "@zilobase/html-to-page": "file:../../packages/html-to-page",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "radix-ui": "^1.4.3",
+        "tailwind-merge": "^3.6.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.3.0",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "@wxt-dev/module-react": "^1.2.0",
+        "react": "19.2.3",
+        "react-dom": "19.2.3",
+        "tailwindcss": "^4.3.0",
+        "typescript": "^5.9.3",
+        "wxt": "^0.20.11"
+      }
+    },
+    "apps/clipper/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "apps/desktop": {
@@ -55,6 +96,7 @@
         "@opentelemetry/sdk-node": "^0.221.0",
         "@tiptap/pm": "^3.23.6",
         "@zilobase/features": "file:../../packages/features",
+        "@zilobase/html-to-page": "file:../../packages/html-to-page",
         "@zilobase/page-context": "file:../../packages/page-context",
         "ai": "^6.0.193",
         "better-auth": "^1.6.25",
@@ -679,13 +721,6 @@
         "node": ">=18"
       }
     },
-    "apps/web/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "apps/web/node_modules/@vitejs/plugin-react": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.0.tgz",
@@ -758,11 +793,16 @@
         "@esbuild/win32-x64": "0.28.2"
       }
     },
-    "apps/web/node_modules/tailwindcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
-      "license": "MIT"
+    "node_modules/@1natsu/wait-element": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@1natsu/wait-element/-/wait-element-4.2.0.tgz",
+      "integrity": "sha512-Om0Q+WE9mNrpY4AwMTvkFiYHv8VM7TML3PvOqXy+w6kAjLjKhGYHYX+305+a6J8RVpds9s7IF2Z5aOPYwULFNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "many-keys-map": "^3.0.0"
+      }
     },
     "node_modules/@ai-sdk/gateway": {
       "version": "3.0.142",
@@ -842,6 +882,113 @@
       },
       "peerDependencies": {
         "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
+      }
+    },
+    "node_modules/@aklinker1/rollup-plugin-visualizer": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@aklinker1/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.12.0.tgz",
+      "integrity": "sha512-X24LvEGw6UFmy0lpGJDmXsMyBD58XmX1bbwsaMLhNoM+UMQfQ3b2RtC+nz4b/NoRK5r6QJSKJHBNVeUdwqybaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^8.4.0",
+        "picomatch": "^2.3.1",
+        "source-map": "^0.7.4",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@aklinker1/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -1892,6 +2039,76 @@
       "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
       "license": "MIT"
     },
+    "node_modules/@devicefarmer/adbkit": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit/-/adbkit-3.3.8.tgz",
+      "integrity": "sha512-7rBLLzWQnBwutH2WZ0EWUkQdihqrnLYCUMaB44hSol9e0/cdIhuNFcqZO0xNheAU6qqHVA8sMiLofkYTgb+lmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@devicefarmer/adbkit-logcat": "^2.1.2",
+        "@devicefarmer/adbkit-monkey": "~1.2.1",
+        "bluebird": "~3.7",
+        "commander": "^9.1.0",
+        "debug": "~4.3.1",
+        "node-forge": "^1.3.1",
+        "split": "~1.0.1"
+      },
+      "bin": {
+        "adbkit": "bin/adbkit"
+      },
+      "engines": {
+        "node": ">= 0.10.4"
+      }
+    },
+    "node_modules/@devicefarmer/adbkit-logcat": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit-logcat/-/adbkit-logcat-2.1.3.tgz",
+      "integrity": "sha512-yeaGFjNBc/6+svbDeul1tNHtNChw6h8pSHAt5D+JsedUrMTN7tla7B15WLDyekxsuS2XlZHRxpuC6m92wiwCNw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@devicefarmer/adbkit-monkey": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@devicefarmer/adbkit-monkey/-/adbkit-monkey-1.2.1.tgz",
+      "integrity": "sha512-ZzZY/b66W2Jd6NHbAhLyDWOEIBWC11VizGFk7Wx7M61JZRz7HR9Cq5P+65RKWUU7u6wgsE8Lmh9nE4Mz+U2eTg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.10.4"
+      }
+    },
+    "node_modules/@devicefarmer/adbkit/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/@devicefarmer/adbkit/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
@@ -2591,6 +2808,422 @@
       "dependencies": {
         "@esbuild-kit/core-utils": "^3.3.2",
         "get-tsconfig": "^4.7.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@fallow-cli/darwin-arm64": {
@@ -3785,6 +4418,51 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+      "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@posthog/browser-common": {
@@ -5715,6 +6393,12 @@
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -7729,10 +8413,34 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -7758,6 +8466,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -7844,6 +8559,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webextension-polyfill": {
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.12.6.tgz",
+      "integrity": "sha512-XTNQSGiQaipt1iocbpHSjYHd+Ujcya+K5H4H2uH7JwycReTFixoYqGWIKih2Ec072NuEW2lAyXRDYmlEx00+cw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/which": {
@@ -8541,6 +9263,112 @@
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@webext-core/fake-browser": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@webext-core/fake-browser/-/fake-browser-1.5.2.tgz",
+      "integrity": "sha512-nkDQwOJ23X5Q7cEtN6LRuBtVFf1KVOFi5GoQAro0lzqdh59F5E+K350j1isbnqYbzsXRh1NJtboudIcHfZtvOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webextension-polyfill": ">=0.10.5",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@webext-core/isolated-element": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@webext-core/isolated-element/-/isolated-element-1.1.5.tgz",
+      "integrity": "sha512-4m6oP8Vzm/68YO1QmkUOZqqUcmyBtA53tji2g00/nYXE3E3IceYgeub7eIqvXDV2Z7xU6cm6qO1IMt4XFVwtvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@webext-core/match-patterns": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@webext-core/match-patterns/-/match-patterns-1.1.0.tgz",
+      "integrity": "sha512-vebVVbcOyva4jyvljIzRJwjFi/OKMLr96LIIxiPeXfA38gE4Z3+H6Y9DwRmn7pWErJGNNHU6XOhOb5ZwicGs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@wxt-dev/browser": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@wxt-dev/browser/-/browser-0.2.9.tgz",
+      "integrity": "sha512-I//1sxt6sSd2Ouj48Q7NfXvGFEKbQAL0wf4I/7sxduMx6S0i5xhJqDUkPCCUj42QnnbTpzybI0TA6OIz9NfMgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@wxt-dev/module-react": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@wxt-dev/module-react/-/module-react-1.2.2.tgz",
+      "integrity": "sha512-+lRLi1r9dAXpLySWSIWHLJ1h/nFzR20iQnx3RNrKyA6oJg4+ClOluVXozHjfPg9Okfy/umtffiOopGayASrg6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitejs/plugin-react": "^4.4.1 || ^5.0.0 || ^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/wxt-dev"
+      },
+      "peerDependencies": {
+        "vite": "^5.4.19 || ^6.3.4 || ^7.0.0 || ^8.0.0-0",
+        "wxt": ">=0.19.16"
+      }
+    },
+    "node_modules/@wxt-dev/module-react/node_modules/@vitejs/plugin-react": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.1.tgz",
+      "integrity": "sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "oxc-transform-react": "^0.145.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "oxc-transform-react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wxt-dev/storage": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@wxt-dev/storage/-/storage-1.2.9.tgz",
+      "integrity": "sha512-dh9TJwvLBM2x4wyy9nE7eYE3wA8pgz1TXSyz7RbdjkJxLfFfWkbeIqiU7VkGy7Vx8sJBmQjoSpk9zSUb3Bjy0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wxt-dev/browser": ">=0.1",
+        "superlock": "^1.3.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/wxt-dev"
+      }
+    },
     "node_modules/@xyflow/react": {
       "version": "12.11.0",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.0.tgz",
@@ -8611,12 +9439,20 @@
         "d3-zoom": "^3.0.0"
       }
     },
+    "node_modules/@zilobase/clipper": {
+      "resolved": "apps/clipper",
+      "link": true
+    },
     "node_modules/@zilobase/desktop": {
       "resolved": "apps/desktop",
       "link": true
     },
     "node_modules/@zilobase/features": {
       "resolved": "packages/features",
+      "link": true
+    },
+    "node_modules/@zilobase/html-to-page": {
+      "resolved": "packages/html-to-page",
       "link": true
     },
     "node_modules/@zilobase/page-context": {
@@ -8671,6 +9507,29 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
@@ -8734,6 +9593,38 @@
         }
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -8741,6 +9632,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -8857,6 +9764,32 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/array-differ": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-4.0.0.tgz",
+      "integrity": "sha512-Q6VPTLMsmXZ47ENG3V+wQyZS1ZxXMxFyYzA+Z/GMrJ6yIutAIEf9wTyroTzmGjNfox9/h3GdGBCVh43GVFx4Uw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
+      "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -8912,6 +9845,16 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/atomically": {
@@ -9243,6 +10186,13 @@
         }
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
@@ -9284,7 +10234,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/bowser": {
@@ -9292,6 +10241,76 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
+    },
+    "node_modules/boxen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^8.0.0",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.21.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
@@ -9385,6 +10404,13 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -9414,6 +10440,45 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/c12": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
+        "exsolve": "^1.0.8",
+        "giget": "^3.2.0",
+        "jiti": "^2.6.1",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.1.0",
+        "pkg-types": "^2.3.0",
+        "rc9": "^3.0.1"
+      },
+      "peerDependencies": {
+        "magicast": "*"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cac": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -9452,6 +10517,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -9590,6 +10668,106 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chrome-launcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.0.tgz",
+      "integrity": "sha512-JbuGuBNss258bvGil7FT4HKdC3SC2K7UAEUqiPy3ACS3Yxo3hAW6bvFpCu2HsIJLgTqxgEX6BkujvzZfLpUD0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^2.0.1"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.cjs"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/chrome-launcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chrome-launcher/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chrome-launcher/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/citty": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
@@ -9613,6 +10791,19 @@
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -9639,6 +10830,69 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/cliui": {
@@ -9814,6 +11068,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/conf": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
@@ -9886,6 +11196,87 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/configstore": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+      "integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "atomically": "^2.0.3",
+        "dot-prop": "^9.0.0",
+        "graceful-fs": "^4.2.11",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/configstore/node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
+    },
+    "node_modules/configstore/node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/content-disposition": {
@@ -10107,7 +11498,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
       "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
@@ -10137,7 +11527,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
       "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
@@ -10162,7 +11551,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/csstype": {
@@ -10717,6 +12105,13 @@
       "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "license": "MIT"
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debounce-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
@@ -10802,6 +12197,16 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deepmerge": {
@@ -10943,6 +12348,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -11006,7 +12418,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
@@ -11021,7 +12432,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11034,7 +12444,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11047,7 +12456,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
@@ -11072,7 +12480,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
@@ -11111,6 +12518,35 @@
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
       "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -11739,6 +13175,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/edge-paths": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
@@ -11940,6 +13386,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -11995,6 +13454,55 @@
         "benchmarks"
       ]
     },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -12002,6 +13510,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/escape-goat": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
+      "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/escape-html": {
@@ -12260,6 +13781,13 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -12433,6 +13961,16 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
@@ -12547,6 +14085,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/filesize": {
+      "version": "11.0.23",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.23.tgz",
+      "integrity": "sha512-EzB9Km94xm3V7szupSlcGVJpkvXWuNtSZmr7qBoj229q7lEJEEYGMk8gwGnA4ZTAGQmHZigTDEIuOfCQXec1fQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 10.8.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -12592,6 +14140,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/firefox-profile": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/firefox-profile/-/firefox-profile-4.7.0.tgz",
+      "integrity": "sha512-aGApEu5bfCNbA4PGUZiRJAIU6jKmghV2UVdklXAofnNtiDjqYw0czLS46W7IfFqVKgKhFB8Ao2YoNGHY4BoIMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "~0.5.x",
+        "fs-extra": "^11.2.0",
+        "ini": "^4.1.3",
+        "minimist": "^1.2.8",
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "firefox-profile": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -12607,6 +14175,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
+      "integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/formdata-node": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-6.0.3.tgz",
+      "integrity": "sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/forwarded": {
@@ -12715,6 +14303,58 @@
       "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
       "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
       "license": "MIT"
+    },
+    "node_modules/fx-runner": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/fx-runner/-/fx-runner-1.4.0.tgz",
+      "integrity": "sha512-rci1g6U0rdTg6bAaBboP7XdRu01dzTAaKXxFf+PUqGuCv6Xu7o8NZdY1D5MvKGIjb6EdS1g3VlXOgksir1uGkg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "commander": "2.9.0",
+        "shell-quote": "1.7.3",
+        "spawn-sync": "1.0.15",
+        "when": "3.7.7",
+        "which": "1.2.4",
+        "winreg": "0.0.12"
+      },
+      "bin": {
+        "fx-runner": "bin/fx-runner"
+      }
+    },
+    "node_modules/fx-runner/node_modules/commander": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "integrity": "sha512-bmkUukX8wAOjHdN26xj5c4ctEV22TQ7dQYhSmuckKhToXrkUn0iIaolHdIxYYqD55nhpSPA9zPQ1yP57GdXP2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-readlink": ">= 1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/fx-runner/node_modules/isexe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+      "integrity": "sha512-d2eJzK691yZwPHcv1LbeAOa91yMJ9QmfTgSO1oXB65ezVhXQsxBac2vEB4bMVms9cGzaA99n6V2viHMq82VLDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fx-runner/node_modules/which": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.4.tgz",
+      "integrity": "sha512-zDRAqDSBudazdfM9zpiI30Fu9ve47htYXcGi3ln0wfKu2a7SmrT6F3VDoYONu//48V8Vz4TdCRNPjtvyRO3yBA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-absolute": "^0.1.7",
+        "isexe": "^1.1.1"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
     },
     "node_modules/geckodriver": {
       "version": "6.1.1",
@@ -12826,6 +14466,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-port-please": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
+      "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -12883,6 +14530,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/giget": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+      "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "giget": "dist/cli.mjs"
+      }
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -12917,6 +14574,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -12950,6 +14614,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-directory/node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -12968,10 +14658,24 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true,
       "license": "MIT"
     },
@@ -13274,11 +14978,17 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/hookable": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/html-url-attributes": {
@@ -13312,7 +15022,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
       "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
-      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -13332,7 +15041,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -13513,6 +15221,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -13576,6 +15294,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-absolute": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+      "integrity": "sha512-Xi9/ZSn4NFapG8RP98iNPMOeaV3mXPisxKxzKtHVqr3g56j/fBn+yZmnxSVAA8lmZbl2J9b/a4kJvfU3hqQYgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-relative": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-alphabetical": {
@@ -13673,6 +15404,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-in-ssh": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
@@ -13703,6 +15450,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-interactive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
@@ -13710,6 +15474,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-npm": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.1.0.tgz",
+      "integrity": "sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13736,6 +15513,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -13746,6 +15536,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-primitive": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
+      "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-promise": {
@@ -13764,6 +15584,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-relative": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+      "integrity": "sha512-wBOr+rNM4gkAZqoLRJI4myw5WzzIdQosFAAbnvfXP5z1LyzgAI3ivOKehC5KfqlQJZoihVhirgtCBj378Eg8GA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-stream": {
@@ -13841,6 +15670,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/isomorphic.js": {
@@ -14056,6 +15895,42 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jszip": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -14102,6 +15977,29 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/katex": {
       "version": "0.16.47",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
@@ -14141,6 +16039,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
     "node_modules/kysely": {
       "version": "0.28.17",
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
@@ -14148,6 +16059,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/latest-version": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
+      "integrity": "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-json": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/layout-base": {
@@ -14231,6 +16158,17 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+      "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "marky": "^1.2.2"
       }
     },
     "node_modules/lightningcss": {
@@ -14504,7 +16442,6 @@
       "version": "0.18.12",
       "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
       "integrity": "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "css-select": "^5.1.0",
@@ -14530,6 +16467,104 @@
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
       "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
       "license": "MIT"
+    },
+    "node_modules/listr2": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.2.tgz",
+      "integrity": "sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.1.tgz",
+      "integrity": "sha512-M0N4xzyzosiIok3svYlEo1sdLZts/8FPgYH/GPC3wvlmPoRvnoManGMrE54waYj3tISA8w6lsdesfVv67qSr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
     },
     "node_modules/locate-app": {
       "version": "2.5.0",
@@ -14598,10 +16633,66 @@
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.zip": {
@@ -14637,6 +16728,106 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/loglevel": {
@@ -14735,6 +16926,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/many-keys-map": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/many-keys-map/-/many-keys-map-3.0.3.tgz",
+      "integrity": "sha512-1DiZmDHPXMBgMRjeUtHy1q1VYmeJscHxhIAexX9z/zjRMP80+0ETuPfssi8z+kMY4DwUgsKuHqpjxgmeA9gBNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fregante"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -14760,6 +16971,13 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -15926,6 +18144,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
     "node_modules/modern-tar": {
       "version": "0.7.7",
       "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
@@ -15989,6 +18239,69 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multimatch": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-6.0.0.tgz",
+      "integrity": "sha512-I7tSVxHGPlmPN/enE3mS1aOSo6bWBfls+3HmuEeCUBCE7gWnm3cBXCBkpurzFjVRwC6Kld8lLaZ1Iv5vOcjvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^3.0.5",
+        "array-differ": "^4.0.0",
+        "array-union": "^3.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/multimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/multimatch/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/multimatch/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/nano-spawn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.1.0.tgz",
+      "integrity": "sha512-yTW+2okrElHiH4fsiz/+/zc0EDo9BDDoC3iKk8dpv1GeRc9nUWzUZHx6TofMWErchhUQR8hY9/Eu1Uja9x1nqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
+      }
+    },
     "node_modules/nanoid": {
       "version": "5.1.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
@@ -16005,6 +18318,16 @@
       },
       "engines": {
         "node": "^18 || >=20"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
       }
     },
     "node_modules/nanostores": {
@@ -16049,6 +18372,114 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-notifier": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
+      "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.5",
+        "shellwords": "^0.1.1",
+        "uuid": "^8.3.2",
+        "which": "^2.0.2"
+      }
+    },
+    "node_modules/node-notifier/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/node-notifier/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/node-notifier/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/node-notifier/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-notifier/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/node-notifier/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/node-releases": {
@@ -16111,13 +18542,30 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/nypm": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.9.tgz",
+      "integrity": "sha512-zxlE2yvSWZWmHcNdT3+5zV2lrCogeE9YOklHrR3dFjqutq5wO7GFDYLFDRXLsYnJzwvy/im9fYoxePvS0VTW0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.2.2",
+        "pathe": "^2.0.3",
+        "tinyexec": "^1.2.4"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/object-assign": {
@@ -16162,6 +18610,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+      "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/on-finished": {
@@ -16293,6 +18770,15 @@
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
+    "node_modules/os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -16363,12 +18849,44 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-json": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
+      "integrity": "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ky": "^1.2.0",
+        "registry-auth-token": "^5.0.2",
+        "registry-url": "^6.0.1",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/package-json/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
@@ -16582,6 +19100,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/perfect-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pg": {
       "version": "8.22.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
@@ -16689,6 +19214,46 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
+      "integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -16697,6 +19262,25 @@
       "engines": {
         "node": ">=16.20.0"
       }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.2.tgz",
+      "integrity": "sha512-v0sVXzj7oPGysr543YYZLYbcJNJsKikSsp/fFzoxQ12ewY3ZZr7oCPC8y7OlmxfYB3QPvriXmuPD8KZggE1vqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.3.0",
+        "exsolve": "^1.1.1",
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/pkg-types/node_modules/confbox": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.3.1.tgz",
+      "integrity": "sha512-cKUSoKa8YxFZZSmraVi7onONx3amu77ngK3kGpsYHDH7drPwCRkQE1RYMPlLRrMtnciRj274XNRxcHxnKmDSnA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pkg-up": {
       "version": "3.1.0",
@@ -16922,6 +19506,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -16930,6 +19531,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-toolbox": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/promise-toolbox/-/promise-toolbox-0.21.0.tgz",
+      "integrity": "sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "make-error": "^1.3.2"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/prompts": {
@@ -17093,6 +19707,13 @@
         "prosemirror-transform": "^1.1.0"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/protobufjs": {
       "version": "7.6.6",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
@@ -17166,6 +19787,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/publish-browser-extension": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/publish-browser-extension/-/publish-browser-extension-4.0.5.tgz",
+      "integrity": "sha512-EePAn3VIHJS/jqCuvs1NgPgoecCT8+RsES76hbgYe2Ze1dyvB0tX60C1PCrV8Z8fv56mW3E59s9Gd/GwWiw7dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "consola": "^3.4.2",
+        "dotenv": "^17.2.4",
+        "form-data-encoder": "^4.1.0",
+        "formdata-node": "^6.0.3",
+        "jsonwebtoken": "^9.0.3",
+        "listr2": "^10.1.0",
+        "ofetch": "^1.5.1",
+        "zod": "3.25.76 || ^4.3.6"
+      },
+      "bin": {
+        "publish-extension": "bin/publish-extension.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/publish-browser-extension/node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -17175,6 +19830,22 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/pupa": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.3.0.tgz",
+      "integrity": "sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-goat": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/qs": {
@@ -17191,6 +19862,23 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/query-selector-shadow-dom": {
       "version": "1.0.1",
@@ -17216,6 +19904,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/radix-ui": {
@@ -17317,6 +20012,50 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rc9": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.1.0.tgz",
+      "integrity": "sha512-ufjkNVzbRHKcCOmTahZkmVsyc3W+MSk3jY03m+a7tGHkIsdVMG9l10/3HvFbWkkKzY5VFp3pkRsIo/UYgmFL7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.7",
+        "destr": "^2.0.5"
       }
     },
     "node_modules/react": {
@@ -17532,6 +20271,30 @@
         "node": ">=10"
       }
     },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -17643,6 +20406,35 @@
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
+    },
+    "node_modules/registry-auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+      "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/npm-conf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
+      "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "1.2.8"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/rehype-harden": {
       "version": "1.1.8",
@@ -17940,6 +20732,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rgb2hex": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.5.tgz",
@@ -17985,12 +20784,6 @@
         "@rolldown/binding-win32-arm64-msvc": "1.2.5",
         "@rolldown/binding-win32-x64-msvc": "1.2.5"
       }
-    },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "license": "MIT"
     },
     "node_modules/rope-sequence": {
       "version": "1.3.4",
@@ -18137,16 +20930,43 @@
         "safe-regex2": "bin/safe-regex2.js"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/scule": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
+      "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -18259,6 +21079,25 @@
       "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
       "license": "MIT"
     },
+    "node_modules/set-value": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.1.0.tgz",
+      "integrity": "sha512-zTEg4HL0RwVrqcWs3ztF+x1vkxfm0lP+MQQFPiMJTKVceBwEV0A569Ou8l9IYQG8jOZdMVI1hGsc0tmeD2o/Lw==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/jonschlinkert",
+        "https://paypal.me/jonathanschlinkert",
+        "https://jonschlinkert.dev/sponsor"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "is-primitive": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=11.0"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -18338,6 +21177,20 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/shiki": {
       "version": "4.1.0",
@@ -18455,6 +21308,39 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -18494,6 +21380,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/sonner": {
@@ -18561,6 +21457,31 @@
         }
       ],
       "license": "Apache-2.0"
+    },
+    "node_modules/spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
+      }
+    },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -18819,6 +21740,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.2.tgz",
+      "integrity": "sha512-4X2FR3UwhNUE9G49aIsJW5hRRR3GXGTBTZRMfv568O60ojM8HcWjV/VxAxCDW3SUND33O6ZY66ZuRcdkj73q2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-4.0.0.tgz",
+      "integrity": "sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^10.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strnum": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
@@ -18834,6 +21788,23 @@
       "dependencies": {
         "anynum": "^1.0.1"
       }
+    },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",
@@ -18858,6 +21829,16 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
       "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
       "license": "MIT"
+    },
+    "node_modules/superlock": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/superlock/-/superlock-1.3.5.tgz",
+      "integrity": "sha512-XpWNthvezZnWp0u7/UL8rBbBOnq2Qx39fw+0RNMC/+eotOd81glzsmIWVH0ejarhTeDQihxOKSbjm2XXFo5a8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -18921,6 +21902,12 @@
         "url": "https://github.com/sponsors/dcastil"
       }
     },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "license": "MIT"
+    },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
@@ -18982,6 +21969,16 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/throttleit": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
@@ -18993,6 +21990,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -19008,9 +22012,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
-      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -19051,6 +22055,16 @@
         "@tiptap/core": "^2.3.0 || ^3.0.0",
         "@tiptap/pm": "^2.3.0 || ^3.0.0",
         "shiki": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {
@@ -19663,6 +22677,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -19677,11 +22698,17 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uhyphen": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
       "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/undici": {
@@ -19728,6 +22755,54 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unimport": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/unimport/-/unimport-6.4.0.tgz",
+      "integrity": "sha512-JJOOuNMFq8b4ZPBKwQUxEcba4MplskDzYI1Lvrf8rJfWphZTWvPNXWa493qsPngHUmub89w6C7j+SeLWTE/UIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.18.0",
+        "escape-string-regexp": "^5.0.0",
+        "estree-walker": "^3.0.3",
+        "local-pkg": "^1.2.1",
+        "magic-string": "^1.1.0",
+        "mlly": "^1.8.2",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.5",
+        "pkg-types": "^2.3.1",
+        "scule": "^1.3.0",
+        "strip-literal": "^4.0.0",
+        "tinyglobby": "^0.2.17",
+        "unplugin": "^3.3.0",
+        "unplugin-utils": "^0.3.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "oxc-parser": "*",
+        "rolldown": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "oxc-parser": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unimport/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/unist-util-find-after": {
@@ -19844,6 +22919,78 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unplugin": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+      "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "picomatch": "^4.0.4",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@farmfe/core": "*",
+        "@rspack/core": "*",
+        "bun-types-no-globals": "*",
+        "esbuild": "*",
+        "rolldown": "*",
+        "rollup": "*",
+        "unloader": "*",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "@farmfe/core": {
+          "optional": true
+        },
+        "@rspack/core": {
+          "optional": true
+        },
+        "bun-types-no-globals": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "unloader": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unplugin-utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+      "integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
@@ -19872,6 +23019,44 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/update-notifier": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.3.1.tgz",
+      "integrity": "sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^8.0.1",
+        "chalk": "^5.3.0",
+        "configstore": "^7.0.0",
+        "is-in-ci": "^1.0.0",
+        "is-installed-globally": "^1.0.0",
+        "is-npm": "^6.0.0",
+        "latest-version": "^9.0.0",
+        "pupa": "^3.1.0",
+        "semver": "^7.6.3",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
+      }
+    },
+    "node_modules/update-notifier/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/urlpattern-polyfill": {
@@ -20141,6 +23326,29 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-6.0.0.tgz",
+      "integrity": "sha512-oj4PVrT+pDh6GYf5wfUXkcZyekYS8kKPfLPXVl8qe324Ec6l4K2DUKNadRbZ3LQl0qGcDz+PyOo7ZAh00Y+JjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^7.0.0",
+        "es-module-lexer": "^2.0.0",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "vite": "^8.0.0"
+      },
+      "bin": {
+        "vite-node": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/antfu"
       }
     },
     "node_modules/vite/node_modules/lightningcss": {
@@ -20561,6 +23769,129 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/watchpack": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
+      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-ext-run": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/web-ext-run/-/web-ext-run-0.2.4.tgz",
+      "integrity": "sha512-rQicL7OwuqWdQWI33JkSXKcp7cuv1mJG8u3jRQwx/8aDsmhbTHs9ZRmNYOL+LX0wX8edIEQX8jj4bB60GoXtKA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@babel/runtime": "7.28.2",
+        "@devicefarmer/adbkit": "3.3.8",
+        "chrome-launcher": "1.2.0",
+        "debounce": "1.2.1",
+        "es6-error": "4.1.1",
+        "firefox-profile": "4.7.0",
+        "fx-runner": "1.4.0",
+        "multimatch": "6.0.0",
+        "node-notifier": "10.0.1",
+        "parse-json": "7.1.1",
+        "pino": "9.7.0",
+        "promise-toolbox": "0.21.0",
+        "set-value": "4.1.0",
+        "source-map-support": "0.5.21",
+        "strip-bom": "5.0.0",
+        "strip-json-comments": "5.0.2",
+        "tmp": "0.2.5",
+        "update-notifier": "7.3.1",
+        "watchpack": "2.4.4",
+        "zip-dir": "2.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      }
+    },
+    "node_modules/web-ext-run/node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/web-ext-run/node_modules/json-parse-even-better-errors": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
+      "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/web-ext-run/node_modules/lines-and-columns": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/web-ext-run/node_modules/parse-json": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
+      "integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.21.4",
+        "error-ex": "^1.3.2",
+        "json-parse-even-better-errors": "^3.0.0",
+        "lines-and-columns": "^2.0.3",
+        "type-fest": "^3.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/web-ext-run/node_modules/strip-bom": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-5.0.0.tgz",
+      "integrity": "sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/web-ext-run/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -20696,6 +24027,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -20733,6 +24071,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/when": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/when/-/when-3.7.7.tgz",
+      "integrity": "sha512-9lFZp/KHoqH6bPKjbWqa+3Dg/K/r2v0X/3/G2x4DBGchVS2QX2VXL3cZV994WQVnTM1/PD71Az25nAzryEUugw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -20764,6 +24116,29 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/winreg": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz",
+      "integrity": "sha512-typ/+JRmi7RqP1NanzFULK36vczznSNN8kWVA9vIqXyv8GhghUlwhGp1Xj3Nms1FsPcNnsQrJOR10N58/nQ9hQ==",
+      "dev": true,
+      "license": "BSD"
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
@@ -20937,6 +24312,89 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/wxt": {
+      "version": "0.20.27",
+      "resolved": "https://registry.npmjs.org/wxt/-/wxt-0.20.27.tgz",
+      "integrity": "sha512-dm6yixz2awM4YMqpTJnsCa8aOPiTrjiIjbWslgR5hCjgwhuft+hLlla339Dt7gIKwQloee4oOruoK++vaX0APA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@1natsu/wait-element": "^4.1.2",
+        "@aklinker1/rollup-plugin-visualizer": "5.12.0",
+        "@webext-core/fake-browser": "^1.3.4",
+        "@webext-core/isolated-element": "^1.1.3",
+        "@webext-core/match-patterns": "^1.0.3",
+        "@wxt-dev/browser": "^0.2.0",
+        "@wxt-dev/storage": "^1.0.0",
+        "async-mutex": "^0.5.0",
+        "c12": "^3.3.4",
+        "cac": "^6.7.14 || ^7.0.0",
+        "chokidar": "^5.0.0",
+        "ci-info": "^4.4.0",
+        "consola": "^3.4.2",
+        "defu": "^6.1.4",
+        "dotenv-expand": "^12.0.3",
+        "esbuild": "^0.27.1",
+        "filesize": "^11.0.17",
+        "get-port-please": "^3.2.0",
+        "giget": "^1.2.3 || ^2.0.0 || ^3.0.0",
+        "hookable": "^6.1.0",
+        "import-meta-resolve": "^4.2.0",
+        "is-wsl": "^3.1.1",
+        "json5": "^2.2.3",
+        "jszip": "^3.10.1",
+        "linkedom": "^0.18.12",
+        "magicast": "^0.5.2",
+        "nano-spawn": "^2.0.0",
+        "nanospinner": "^1.2.2",
+        "normalize-path": "^3.0.0",
+        "nypm": "^0.6.5",
+        "ohash": "^2.0.11",
+        "open": "^11.0.0",
+        "perfect-debounce": "^2.1.0",
+        "picomatch": "^4.0.3",
+        "prompts": "^2.4.2",
+        "publish-browser-extension": "^2.3.0 || ^3.0.2 || ^4.0.5",
+        "scule": "^1.3.0",
+        "tinyglobby": "^0.2.16",
+        "unimport": "^3.13.1 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "vite": "^5.4.19 || ^6.3.4 || ^7.0.0 || ^8.0.0-0",
+        "vite-node": "^3.2.4 || ^5.0.0 || ^6.0.0",
+        "web-ext-run": "^0.2.4"
+      },
+      "bin": {
+        "wxt": "bin/wxt.mjs",
+        "wxt-publish-extension": "bin/wxt-publish-extension.mjs"
+      },
+      "engines": {
+        "bun": ">=1.2.0",
+        "node": ">=20.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/wxt-dev"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml-naming": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
@@ -20951,6 +24409,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {
@@ -21168,6 +24650,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zip-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/zip-dir/-/zip-dir-2.0.0.tgz",
+      "integrity": "sha512-uhlsJZWz26FLYXOD6WVuq+fIcZ3aBPGo/cFdiLlv3KNwpa52IF3ISV8fLhQLiqVu5No3VhlqlgthN6gehil1Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.0",
+        "jszip": "^3.2.2"
+      }
+    },
     "node_modules/zip-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
@@ -21266,6 +24759,27 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "packages/html-to-page": {
+      "name": "@zilobase/html-to-page",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.23.6",
+        "@tiptap/extension-link": "^3.23.6",
+        "@tiptap/extension-table": "^3.23.6",
+        "@tiptap/extension-table-cell": "^3.23.6",
+        "@tiptap/extension-table-header": "^3.23.6",
+        "@tiptap/extension-table-row": "^3.23.6",
+        "@tiptap/extension-task-item": "^3.23.6",
+        "@tiptap/extension-task-list": "^3.23.6",
+        "@tiptap/starter-kit": "^3.23.6",
+        "linkedom": "^0.18.12"
+      },
+      "devDependencies": {
+        "@types/node": "^25.9.1",
+        "vitest": "^4.1.10"
       }
     },
     "packages/markdown-text-splitter": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "workspaces": [
     "apps/*",
     "packages/features",
+    "packages/html-to-page",
     "packages/markdown-text-splitter",
     "packages/page-context",
     "packages/tiptap-comment-extension"
@@ -19,6 +20,8 @@
     "dev": "npm run dev:web",
     "build": "npm run build:web",
     "dev:web": "npm run dev --workspace @zilobase/web",
+    "dev:clipper": "npm run dev --workspace @zilobase/clipper",
+    "build:clipper": "npm run build --workspace @zilobase/clipper",
     "build:web": "npm run build --workspace @zilobase/web",
     "test:web": "npm run test --workspace @zilobase/web",
     "test:update-local": "node scripts/desktop/test-update.mjs",
@@ -54,7 +57,7 @@
     "quality:fallow:full": "npm run quality:fallow:dead && npm run quality:fallow:dupes && npm run quality:fallow:health",
     "quality:web-bundle": "node scripts/web/check-bundle-budget.mjs",
     "typecheck": "npm run typecheck --workspaces --if-present",
-    "test:packages": "npm test --workspace @zilobase/features && npm test --workspace @zilobase/page-context",
+    "test:packages": "npm test --workspace @zilobase/features && npm test --workspace @zilobase/page-context && npm test --workspace @zilobase/html-to-page",
     "verify:core": "npm run tokens:check && npm run test:tooling && npm run test:community-boundary && npm run typecheck && npm run test:packages && npm run test:web && npm run build:web && npm run test:server && npm run quality:fallow -- --summary",
     "verify:desktop": "cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml --check && cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --locked --all-targets -- -D warnings && cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml --locked",
     "verify:architecture": "npm run test:architecture && npm run quality:fallow:full",

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -31,6 +31,14 @@
       "types": "./src/api-keys/index.ts",
       "default": "./src/api-keys/index.ts"
     },
+    "./clips": {
+      "types": "./src/clips/index.ts",
+      "default": "./src/clips/index.ts"
+    },
+    "./clips/contracts": {
+      "types": "./src/clips/contracts.ts",
+      "default": "./src/clips/contracts.ts"
+    },
     "./auth": {
       "types": "./src/auth/index.ts",
       "default": "./src/auth/index.ts"

--- a/packages/features/src/clips/contracts.ts
+++ b/packages/features/src/clips/contracts.ts
@@ -1,0 +1,75 @@
+export const CLIP_CAPTURE_MODES = [
+  "article",
+  "page",
+  "selection",
+  "bookmark",
+  "highlights",
+] as const
+
+export type ClipCaptureMode = (typeof CLIP_CAPTURE_MODES)[number]
+
+export const CLIP_DUPLICATE_STRATEGIES = [
+  "create",
+  "reject",
+  "open-existing",
+] as const
+
+export type ClipDuplicateStrategy = (typeof CLIP_DUPLICATE_STRATEGIES)[number]
+
+export type ClipPropertyValue = {
+  propertyId: string
+  value: unknown
+}
+
+export type CreateClipRequest = {
+  workspaceId: string
+  parentPageId?: string | null
+  databaseId?: string | null
+  teamspaceId?: string | null
+  title: string
+  sourceUrl: string
+  canonicalUrl?: string | null
+  captureMode: ClipCaptureMode
+  note?: string | null
+  html?: string | null
+  content?: unknown | null
+  metadata?: {
+    author?: string | null
+    published?: string | null
+    description?: string | null
+    image?: string | null
+    favicon?: string | null
+    site?: string | null
+  }
+  propertyValues?: ClipPropertyValue[]
+  duplicateStrategy?: ClipDuplicateStrategy
+}
+
+export type CreateClipResponse = {
+  pageId: string
+  databaseRowId?: string
+  url: string
+  duplicateOf?: string
+}
+
+export type ClipDuplicateRecord = {
+  pageId: string
+  title: string
+  url: string
+}
+
+export function isClipCaptureMode(value: unknown): value is ClipCaptureMode {
+  return (
+    typeof value === "string" &&
+    (CLIP_CAPTURE_MODES as readonly string[]).includes(value)
+  )
+}
+
+export function isClipDuplicateStrategy(
+  value: unknown,
+): value is ClipDuplicateStrategy {
+  return (
+    typeof value === "string" &&
+    (CLIP_DUPLICATE_STRATEGIES as readonly string[]).includes(value)
+  )
+}

--- a/packages/features/src/clips/index.ts
+++ b/packages/features/src/clips/index.ts
@@ -1,0 +1,12 @@
+export {
+  CLIP_CAPTURE_MODES,
+  CLIP_DUPLICATE_STRATEGIES,
+  isClipCaptureMode,
+  isClipDuplicateStrategy,
+  type ClipCaptureMode,
+  type ClipDuplicateRecord,
+  type ClipDuplicateStrategy,
+  type ClipPropertyValue,
+  type CreateClipRequest,
+  type CreateClipResponse,
+} from "./contracts"

--- a/packages/features/src/pages/item-relationships.ts
+++ b/packages/features/src/pages/item-relationships.ts
@@ -9,7 +9,15 @@ export type EmbeddedItemsOpenAs = "dialog" | "sidepanel";
 
 export type PageIconPosition = "inline" | "top";
 
+export type PageClipMetadata = {
+  capturedAt?: string | null;
+  captureMode?: string | null;
+  canonicalUrl?: string | null;
+  sourceUrl?: string | null;
+};
+
 export type PageMetadata = {
+  clip?: PageClipMetadata | null;
   cover?: string | null;
   emoji?: string | null;
   embeddedItemsOpenAs?: EmbeddedItemsOpenAs | null;

--- a/packages/html-to-page/package.json
+++ b/packages/html-to-page/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@zilobase/html-to-page",
+  "type": "module",
+  "version": "0.0.0",
+  "license": "MIT",
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "linkedom": "^0.18.12",
+    "@tiptap/core": "^3.23.6",
+    "@tiptap/extension-link": "^3.23.6",
+    "@tiptap/extension-table": "^3.23.6",
+    "@tiptap/extension-table-cell": "^3.23.6",
+    "@tiptap/extension-table-header": "^3.23.6",
+    "@tiptap/extension-table-row": "^3.23.6",
+    "@tiptap/extension-task-item": "^3.23.6",
+    "@tiptap/extension-task-list": "^3.23.6",
+    "@tiptap/starter-kit": "^3.23.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.1",
+    "vitest": "^4.1.10"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./extract-clip-metadata": {
+      "types": "./src/extract-clip-metadata.ts",
+      "default": "./src/extract-clip-metadata.ts"
+    }
+  }
+}

--- a/packages/html-to-page/src/assemble-clip-document.ts
+++ b/packages/html-to-page/src/assemble-clip-document.ts
@@ -1,0 +1,51 @@
+import { isAllowedHttpUrl, isAllowedImageUrl } from "./safe-url"
+import type { AssembleClipDocumentInput, PageDocument, PageDocumentNode } from "./types"
+
+export function assembleClipDocument(input: AssembleClipDocumentInput): PageDocument {
+  const content: PageDocumentNode[] = []
+  const bookmark = bookmarkBlock(input)
+  if (bookmark) content.push(bookmark)
+
+  const note = input.note?.trim()
+  if (note) {
+    content.push({
+      type: "blockquote",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: note }],
+        },
+      ],
+    })
+  }
+
+  const body = input.content?.content?.filter((node) => node.type !== "bookmarkBlock") ?? []
+  content.push(...body)
+
+  return {
+    type: "doc",
+    content: content.length > 0 ? content : [{ type: "paragraph" }],
+  }
+}
+
+function bookmarkBlock(input: AssembleClipDocumentInput): PageDocumentNode | null {
+  if (!isAllowedHttpUrl(input.sourceUrl)) return null
+  return {
+    type: "bookmarkBlock",
+    attrs: {
+      href: input.sourceUrl,
+      title: input.title,
+      description: input.description ?? null,
+      favicon: optionalHttp(input.favicon),
+      image: optionalImage(input.image),
+    },
+  }
+}
+
+function optionalHttp(value: string | null | undefined) {
+  return value && isAllowedHttpUrl(value) ? value : null
+}
+
+function optionalImage(value: string | null | undefined) {
+  return value && isAllowedImageUrl(value) ? value : null
+}

--- a/packages/html-to-page/src/clipper-extensions.ts
+++ b/packages/html-to-page/src/clipper-extensions.ts
@@ -1,0 +1,168 @@
+import { Node, mergeAttributes } from "@tiptap/core"
+import Link from "@tiptap/extension-link"
+import { Table } from "@tiptap/extension-table"
+import { TableCell } from "@tiptap/extension-table-cell"
+import { TableHeader } from "@tiptap/extension-table-header"
+import { TableRow } from "@tiptap/extension-table-row"
+import TaskItem from "@tiptap/extension-task-item"
+import TaskList from "@tiptap/extension-task-list"
+import StarterKit from "@tiptap/starter-kit"
+
+import { isAllowedEmbedSrc, isAllowedHttpUrl, isAllowedImageUrl } from "./safe-url"
+
+const ClipperImageBlock = Node.create({
+  name: "imageBlock",
+  group: "block",
+  atom: true,
+  addAttributes() {
+    return {
+      src: { default: null },
+      alt: { default: null },
+      title: { default: null },
+      width: { default: null },
+    }
+  },
+  parseHTML() {
+    return [
+      { tag: 'div[data-type="imageBlock"]' },
+      {
+        tag: "img[src]",
+        getAttrs: (element) => {
+          if (!isElement(element)) return false
+          const src = element.getAttribute("src")
+          if (!isAllowedImageUrl(src)) return false
+          return {
+            src,
+            alt: element.getAttribute("alt"),
+            title: element.getAttribute("title"),
+          }
+        },
+      },
+    ]
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["img", mergeAttributes(HTMLAttributes, { "data-type": "imageBlock" })]
+  },
+})
+
+const ClipperVideoBlock = Node.create({
+  name: "videoBlock",
+  group: "block",
+  atom: true,
+  addAttributes() {
+    return {
+      src: { default: null },
+      title: { default: null },
+    }
+  },
+  parseHTML() {
+    return [
+      { tag: 'div[data-type="videoBlock"]' },
+      {
+        tag: "video[src]",
+        getAttrs: (element) => {
+          if (!isElement(element)) return false
+          const src = element.getAttribute("src")
+          if (!isAllowedHttpUrl(src)) return false
+          return { src, title: element.getAttribute("title") }
+        },
+      },
+    ]
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["video", mergeAttributes(HTMLAttributes, { "data-type": "videoBlock" })]
+  },
+})
+
+const ClipperEmbedBlock = Node.create({
+  name: "embedBlock",
+  group: "block",
+  atom: true,
+  addAttributes() {
+    return {
+      src: { default: null },
+      title: { default: null },
+      provider: { default: null },
+      width: { default: null },
+    }
+  },
+  parseHTML() {
+    return [
+      { tag: 'div[data-type="embedBlock"]' },
+      {
+        tag: "iframe",
+        priority: 60,
+        getAttrs: (element) => {
+          if (!isElement(element)) return false
+          const src = element.getAttribute("src")
+          if (!isAllowedEmbedSrc(src)) return false
+          return {
+            src,
+            title: element.getAttribute("title"),
+            provider: embedProvider(src),
+          }
+        },
+      },
+    ]
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["iframe", mergeAttributes(HTMLAttributes, { "data-type": "embedBlock" })]
+  },
+})
+
+const ClipperBookmarkBlock = Node.create({
+  name: "bookmarkBlock",
+  group: "block",
+  atom: true,
+  addAttributes() {
+    return {
+      href: { default: null },
+      title: { default: null },
+      description: { default: null },
+      favicon: { default: null },
+      image: { default: null },
+    }
+  },
+  parseHTML() {
+    return [{ tag: 'div[data-type="bookmarkBlock"]' }]
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ["div", mergeAttributes(HTMLAttributes, { "data-type": "bookmarkBlock" })]
+  },
+})
+
+function isElement(value: unknown): value is Element {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      "getAttribute" in value &&
+      typeof value.getAttribute === "function",
+  )
+}
+
+function embedProvider(src: string | null) {
+  if (!src) return null
+  try {
+    const host = new URL(src).hostname.replace(/^www\./, "")
+    if (host === "youtube.com" || host === "youtube-nocookie.com") return "youtube"
+    if (host === "vimeo.com" || host === "player.vimeo.com") return null
+    return null
+  } catch {
+    return null
+  }
+}
+
+export const clipperExtensions = [
+  StarterKit.configure({ link: false }),
+  Link.configure({ openOnClick: false, autolink: false }),
+  TaskList,
+  TaskItem.configure({ nested: true }),
+  Table.configure({ resizable: false }),
+  TableRow,
+  TableHeader,
+  TableCell,
+  ClipperImageBlock,
+  ClipperVideoBlock,
+  ClipperEmbedBlock,
+  ClipperBookmarkBlock,
+]

--- a/packages/html-to-page/src/dom-test-setup.ts
+++ b/packages/html-to-page/src/dom-test-setup.ts
@@ -1,0 +1,29 @@
+import { parseHTML } from "linkedom"
+
+export function ensureDomParser() {
+  if (typeof globalThis.DOMParser === "function") {
+    return
+  }
+  installDomParser()
+}
+
+export function installDomParser() {
+  const { document, window } = parseHTML("<!doctype html><html><body></body></html>")
+  const runtime = globalThis as typeof globalThis & {
+    document: Document
+    window: Window & typeof globalThis
+  }
+  runtime.document = document as unknown as Document
+  runtime.window = window as unknown as Window & typeof globalThis
+  runtime.Node = (window.Node ?? { TEXT_NODE: 3, ELEMENT_NODE: 1 }) as typeof Node
+  runtime.HTMLElement = window.HTMLElement as unknown as typeof HTMLElement
+  runtime.Element = window.Element as unknown as typeof Element
+  runtime.DOMParser = class DOMParser {
+    parseFromString(html: string, type: DOMParserSupportedType) {
+      if (type !== "text/html") {
+        throw new Error(`Unsupported DOMParser type: ${type}`)
+      }
+      return parseHTML(`<!doctype html>${html}`).document as unknown as Document
+    }
+  } as unknown as typeof DOMParser
+}

--- a/packages/html-to-page/src/extract-clip-metadata.ts
+++ b/packages/html-to-page/src/extract-clip-metadata.ts
@@ -1,0 +1,150 @@
+import { isAllowedHttpUrl, isAllowedImageUrl, parseAbsoluteUrl } from "./safe-url"
+import type { ClipMetadata } from "./types"
+
+export type { ClipMetadata } from "./types"
+
+export function extractClipMetadata(document: Document, pageUrl: string): ClipMetadata {
+  const url = parseAbsoluteUrl(pageUrl)
+  const canonical = absoluteFrom(
+    document.querySelector('link[rel="canonical"]')?.getAttribute("href"),
+    pageUrl,
+  )
+  const title =
+    metaContent(document, "og:title") ??
+    metaContent(document, "twitter:title") ??
+    document.querySelector("title")?.textContent?.trim() ??
+    url?.hostname ??
+    pageUrl
+  const description =
+    metaContent(document, "og:description") ??
+    metaContent(document, "twitter:description") ??
+    namedMeta(document, "description")
+  const image = firstAllowedImage(
+    metaContent(document, "og:image"),
+    metaContent(document, "twitter:image"),
+    pageUrl,
+  )
+  const favicon = firstAllowedHttp(
+    document.querySelector('link[rel="icon"]')?.getAttribute("href"),
+    document.querySelector('link[rel="shortcut icon"]')?.getAttribute("href"),
+    document.querySelector('link[rel="apple-touch-icon"]')?.getAttribute("href"),
+    pageUrl,
+  )
+  const site = metaContent(document, "og:site_name")
+  const author =
+    namedMeta(document, "author") ??
+    jsonLdString(document, "author") ??
+    jsonLdString(document, "creator")
+  const published =
+    metaContent(document, "article:published_time") ??
+    namedMeta(document, "date") ??
+    jsonLdString(document, "datePublished")
+  const schemaType = jsonLdType(document)
+  const selectionText = document.getSelection?.()?.toString().trim() || null
+  const text = document.body?.textContent?.replace(/\s+/g, " ").trim() ?? ""
+
+  return {
+    author,
+    canonicalUrl: canonical,
+    description,
+    domain: url?.hostname ?? "",
+    favicon,
+    image,
+    published,
+    schemaType,
+    selectionText,
+    site,
+    title,
+    url: pageUrl,
+    wordCount: text ? text.split(" ").filter(Boolean).length : 0,
+  }
+}
+
+function metaContent(document: Document, property: string) {
+  return (
+    document
+      .querySelector(`meta[property="${property}"]`)
+      ?.getAttribute("content")
+      ?.trim() ||
+    document.querySelector(`meta[name="${property}"]`)?.getAttribute("content")?.trim() ||
+    null
+  )
+}
+
+function namedMeta(document: Document, name: string) {
+  return document.querySelector(`meta[name="${name}"]`)?.getAttribute("content")?.trim() || null
+}
+
+function jsonLdString(document: Document, key: string) {
+  for (const script of document.querySelectorAll('script[type="application/ld+json"]')) {
+    try {
+      const data = JSON.parse(script.textContent ?? "")
+      const value = readJsonLd(data, key)
+      if (typeof value === "string" && value.trim()) return value.trim()
+      if (value && typeof value === "object" && "name" in value && typeof value.name === "string") {
+        return value.name
+      }
+    } catch {
+      continue
+    }
+  }
+  return null
+}
+
+function jsonLdType(document: Document) {
+  for (const script of document.querySelectorAll('script[type="application/ld+json"]')) {
+    try {
+      const data = JSON.parse(script.textContent ?? "")
+      const type = readJsonLd(data, "@type")
+      if (typeof type === "string") return type
+    } catch {
+      continue
+    }
+  }
+  return null
+}
+
+function readJsonLd(data: unknown, key: string): unknown {
+  if (Array.isArray(data)) {
+    for (const item of data) {
+      const value = readJsonLd(item, key)
+      if (value) return value
+    }
+    return null
+  }
+  if (data && typeof data === "object" && key in data) {
+    return (data as Record<string, unknown>)[key]
+  }
+  if (data && typeof data === "object" && "@graph" in data) {
+    return readJsonLd((data as { "@graph": unknown })["@graph"], key)
+  }
+  return null
+}
+
+function absoluteFrom(value: string | null | undefined, base: string) {
+  if (!value) return null
+  try {
+    const url = new URL(value, base).toString()
+    return isAllowedHttpUrl(url) ? url : null
+  } catch {
+    return null
+  }
+}
+
+function firstAllowedHttp(...values: Array<string | null | undefined>) {
+  const base = values.at(-1) ?? ""
+  for (const value of values.slice(0, -1)) {
+    const url = absoluteFrom(value, base)
+    if (url) return url
+  }
+  return null
+}
+
+function firstAllowedImage(...values: Array<string | null | undefined>) {
+  const base = values.at(-1) ?? ""
+  for (const value of values.slice(0, -1)) {
+    const url = absoluteFrom(value, base)
+    if (url && isAllowedImageUrl(url)) return url
+  }
+  return null
+}

--- a/packages/html-to-page/src/html-to-page-content.test.ts
+++ b/packages/html-to-page/src/html-to-page-content.test.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "vitest"
+
+import { installDomParser } from "./dom-test-setup"
+import { assembleClipDocument } from "./assemble-clip-document"
+import { extractClipMetadata } from "./extract-clip-metadata"
+import { htmlToPageContent } from "./html-to-page-content"
+import { sanitizeHtml } from "./sanitize-html"
+import { sanitizePageContent } from "./sanitize-page-content"
+
+installDomParser()
+
+test("htmlToPageContent converts headings, lists, code, and tables", () => {
+  const document = htmlToPageContent(`
+    <h1>Title</h1>
+    <p>Hello <strong>world</strong></p>
+    <ul><li>One</li><li>Two</li></ul>
+    <pre><code>const x = 1</code></pre>
+    <table><tr><th>Name</th></tr><tr><td>Ada</td></tr></table>
+  `)
+
+  const types = document.content.map((node) => node.type)
+  expect(types).toEqual(["heading", "paragraph", "bulletList", "codeBlock", "table"])
+  expect(document.content[0]?.attrs?.level).toBe(1)
+})
+
+test("htmlToPageContent keeps images and youtube embeds", () => {
+  const document = htmlToPageContent(`
+    <p>Photo</p>
+    <img src="https://cdn.example.com/photo.png" alt="Photo">
+    <iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" title="Video"></iframe>
+  `)
+
+  const types = document.content.map((node) => node.type)
+  expect(types).toContain("imageBlock")
+  expect(types).toContain("embedBlock")
+  const image = document.content.find((node) => node.type === "imageBlock")
+  expect(image?.attrs?.src).toBe("https://cdn.example.com/photo.png")
+})
+
+test("sanitizeHtml drops scripts, javascript urls, and unknown iframes", () => {
+  const html = sanitizeHtml(`
+    <p>Safe</p>
+    <script>alert(1)</script>
+    <a href="javascript:alert(1)">Click</a>
+    <img src="javascript:alert(1)">
+    <iframe src="https://evil.example/embed"></iframe>
+    <iframe src="https://www.youtube.com/embed/ok"></iframe>
+  `)
+
+  expect(html).toContain("Safe")
+  expect(html).not.toContain("script")
+  expect(html).not.toContain("javascript:")
+  expect(html).not.toContain("evil.example")
+  expect(html).toContain("youtube.com/embed/ok")
+})
+
+test("sanitizePageContent drops unknown nodes and javascript links", () => {
+  const sanitized = sanitizePageContent({
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "bad",
+            marks: [{ type: "link", attrs: { href: "javascript:alert(1)" } }],
+          },
+        ],
+      },
+      { type: "imageBlock", attrs: { src: "javascript:alert(1)" } },
+      { type: "askAiBlock", content: [{ type: "paragraph", content: [{ type: "text", text: "keep" }] }] },
+    ],
+  })
+
+  expect(sanitized.content.some((node) => node.type === "imageBlock")).toBe(false)
+  expect(sanitized.content.some((node) => node.type === "askAiBlock")).toBe(false)
+  const text = sanitized.content[0]
+  expect(text?.content?.[0]?.marks?.some((mark) => mark.type === "link")).toBeFalsy()
+})
+
+test("empty html becomes an empty paragraph document", () => {
+  const document = htmlToPageContent("   ")
+  expect(document).toEqual({ type: "doc", content: [{ type: "paragraph" }] })
+})
+
+test("assembleClipDocument prepends a bookmark and optional note", () => {
+  const document = assembleClipDocument({
+    sourceUrl: "https://example.com/article",
+    title: "Article",
+    description: "Desc",
+    favicon: "https://example.com/favicon.ico",
+    image: "https://example.com/og.png",
+    note: "Read later",
+    content: {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "Body" }] }],
+    },
+  })
+
+  expect(document.content[0]?.type).toBe("bookmarkBlock")
+  expect(document.content[0]?.attrs?.href).toBe("https://example.com/article")
+  expect(document.content[1]?.type).toBe("blockquote")
+  expect(document.content[2]?.type).toBe("paragraph")
+})
+
+test("extractClipMetadata reads open graph and json-ld", () => {
+  const parsed = new DOMParser().parseFromString(
+    `<!doctype html>
+    <html>
+      <head>
+        <title>Fallback</title>
+        <meta property="og:title" content="OG Title">
+        <meta property="og:description" content="OG Desc">
+        <meta property="og:image" content="https://example.com/og.png">
+        <meta property="og:site_name" content="Example">
+        <link rel="canonical" href="https://example.com/canonical">
+        <link rel="icon" href="/favicon.ico">
+        <script type="application/ld+json">{"@type":"Article","author":{"name":"Ada"},"datePublished":"2024-01-01"}</script>
+      </head>
+      <body><p>one two three</p></body>
+    </html>`,
+    "text/html",
+  )
+
+  const metadata = extractClipMetadata(parsed, "https://example.com/article")
+  expect(metadata.title).toBe("OG Title")
+  expect(metadata.description).toBe("OG Desc")
+  expect(metadata.canonicalUrl).toBe("https://example.com/canonical")
+  expect(metadata.image).toBe("https://example.com/og.png")
+  expect(metadata.favicon).toBe("https://example.com/favicon.ico")
+  expect(metadata.author).toBe("Ada")
+  expect(metadata.published).toBe("2024-01-01")
+  expect(metadata.schemaType).toBe("Article")
+  expect(metadata.site).toBe("Example")
+  expect(metadata.domain).toBe("example.com")
+  expect(metadata.wordCount).toBeGreaterThan(0)
+})

--- a/packages/html-to-page/src/html-to-page-content.ts
+++ b/packages/html-to-page/src/html-to-page-content.ts
@@ -1,0 +1,247 @@
+import { generateJSON, type JSONContent } from "@tiptap/core"
+
+import { clipperExtensions } from "./clipper-extensions"
+import { sanitizeHtml } from "./sanitize-html"
+import { sanitizePageContent } from "./sanitize-page-content"
+import type { PageDocument, PageDocumentNode } from "./types"
+
+export function htmlToPageContent(html: string): PageDocument {
+  const sanitized = sanitizeHtml(html)
+  const source = sanitized || "<p></p>"
+
+  try {
+    const parsed = generateJSON(source, clipperExtensions) as PageDocument
+    const compacted = removeEmptyTopLevelParagraphs(parsed)
+    if (!isEmptyDocument(compacted) && preservesExpectedMedia(source, compacted)) {
+      return sanitizePageContent(compacted)
+    }
+  } catch {
+    // Fall back to the walker below.
+  }
+
+  return sanitizePageContent(removeEmptyTopLevelParagraphs(fallbackHtmlToContent(source)))
+}
+
+function preservesExpectedMedia(source: string, content: PageDocument) {
+  const types = new Set(content.content.map((node) => node.type))
+  if (/<img\b/i.test(source) && !types.has("imageBlock")) return false
+  if (/<iframe\b/i.test(source) && !types.has("embedBlock")) return false
+  if (/<video\b/i.test(source) && !types.has("videoBlock")) return false
+  return true
+}
+
+function isEmptyDocument(content: PageDocument) {
+  return (
+    content.type === "doc" &&
+    content.content.length === 1 &&
+    content.content[0]?.type === "paragraph" &&
+    !content.content[0].content
+  )
+}
+
+function removeEmptyTopLevelParagraphs(content: JSONContent): PageDocument {
+  if (content.type !== "doc") {
+    return emptyDocument()
+  }
+
+  const blocks =
+    content.content?.filter((block) => !isEmptyParagraph(block as PageDocumentNode)) ??
+    []
+
+  return {
+    type: "doc",
+    content: (blocks.length > 0 ? blocks : [{ type: "paragraph" }]) as PageDocumentNode[],
+  }
+}
+
+function isEmptyParagraph(content: PageDocumentNode) {
+  return content.type === "paragraph" && !content.content
+}
+
+function fallbackHtmlToContent(html: string): PageDocument {
+  const document = new DOMParser().parseFromString(
+    `<main>${html}</main>`,
+    "text/html",
+  )
+  const root = document.querySelector("main") ?? document.body
+  const content = Array.from(root.childNodes).flatMap((node) => blockNodeToJson(node))
+
+  return {
+    type: "doc",
+    content: content.length > 0 ? content : [{ type: "paragraph" }],
+  }
+}
+
+const TEXT_NODE = 3
+const ELEMENT_NODE = 1
+
+function blockNodeToJson(node: Node): PageDocumentNode[] {
+  if (node.nodeType === TEXT_NODE) {
+    const text = node.textContent?.trim()
+    return text ? [{ type: "paragraph", content: [{ type: "text", text }] }] : []
+  }
+
+  if (node.nodeType !== ELEMENT_NODE) {
+    return []
+  }
+
+  const element = node as Element
+  const tagName = element.tagName.toLowerCase()
+
+  if (/^h[1-6]$/.test(tagName)) {
+    return [
+      {
+        type: "heading",
+        attrs: { level: Number(tagName.slice(1)) },
+        ...withInlineContent(element),
+      },
+    ]
+  }
+
+  if (tagName === "p") {
+    return [{ type: "paragraph", ...withInlineContent(element) }]
+  }
+
+  if (tagName === "blockquote") {
+    return [
+      {
+        type: "blockquote",
+        content: childBlocks(element, [
+          { type: "paragraph", ...withInlineContent(element) },
+        ]),
+      },
+    ]
+  }
+
+  if (tagName === "pre") {
+    return [
+      {
+        type: "codeBlock",
+        attrs: { language: null },
+        content: [{ type: "text", text: element.textContent ?? "" }],
+      },
+    ]
+  }
+
+  if (tagName === "hr") {
+    return [{ type: "horizontalRule" }]
+  }
+
+  if (tagName === "img") {
+    const src = element.getAttribute("src")
+    return src
+      ? [
+          {
+            type: "imageBlock",
+            attrs: {
+              src,
+              alt: element.getAttribute("alt"),
+              title: element.getAttribute("title"),
+            },
+          },
+        ]
+      : []
+  }
+
+  if (tagName === "iframe") {
+    const src = element.getAttribute("src")
+    return src
+      ? [
+          {
+            type: "embedBlock",
+            attrs: {
+              src,
+              title: element.getAttribute("title"),
+              provider: src.includes("youtube") ? "youtube" : null,
+            },
+          },
+        ]
+      : []
+  }
+
+  if (tagName === "ul" || tagName === "ol") {
+    return [
+      {
+        type: tagName === "ol" ? "orderedList" : "bulletList",
+        content: Array.from(element.children).map((item) => ({
+          type: "listItem",
+          content: childBlocks(item, [
+            { type: "paragraph", ...withInlineContent(item) },
+          ]),
+        })),
+      },
+    ]
+  }
+
+  if (tagName === "table") {
+    return [
+      {
+        type: "table",
+        content: Array.from(element.querySelectorAll("tr")).map((row) => ({
+          type: "tableRow",
+          content: Array.from(row.children).map((cell) => ({
+            type: cell.tagName.toLowerCase() === "th" ? "tableHeader" : "tableCell",
+            content: [{ type: "paragraph", ...withInlineContent(cell) }],
+          })),
+        })),
+      },
+    ]
+  }
+
+  return childBlocks(element)
+}
+
+function childBlocks(element: Element, fallback: PageDocumentNode[] = []) {
+  const blocks = Array.from(element.childNodes).flatMap((child) => blockNodeToJson(child))
+  return blocks.length > 0 ? blocks : fallback
+}
+
+function withInlineContent(element: Element): Pick<PageDocumentNode, "content"> {
+  const content = Array.from(element.childNodes).flatMap((child) =>
+    inlineNodeToJson(child),
+  )
+  return content.length > 0 ? { content } : {}
+}
+
+function inlineNodeToJson(
+  node: Node,
+  marks: PageDocumentNode["marks"] = [],
+): PageDocumentNode[] {
+  if (node.nodeType === TEXT_NODE) {
+    const text = node.textContent ?? ""
+    return text ? [{ type: "text", text, ...(marks.length ? { marks } : {}) }] : []
+  }
+
+  if (node.nodeType !== ELEMENT_NODE) {
+    return []
+  }
+
+  const element = node as Element
+  const tagName = element.tagName.toLowerCase()
+  const nextMarks = [...marks]
+
+  if (tagName === "strong" || tagName === "b") {
+    nextMarks.push({ type: "bold" })
+  } else if (tagName === "em" || tagName === "i") {
+    nextMarks.push({ type: "italic" })
+  } else if (tagName === "code") {
+    nextMarks.push({ type: "code" })
+  } else if (tagName === "a") {
+    nextMarks.push({
+      type: "link",
+      attrs: { href: element.getAttribute("href") },
+    })
+  }
+
+  if (tagName === "br") {
+    return [{ type: "hardBreak" }]
+  }
+
+  return Array.from(element.childNodes).flatMap((child) =>
+    inlineNodeToJson(child, nextMarks),
+  )
+}
+
+function emptyDocument(): PageDocument {
+  return { type: "doc", content: [{ type: "paragraph" }] }
+}

--- a/packages/html-to-page/src/index.ts
+++ b/packages/html-to-page/src/index.ts
@@ -1,0 +1,14 @@
+export {
+  assembleClipDocument,
+} from "./assemble-clip-document"
+export { ensureDomParser, installDomParser } from "./dom-test-setup"
+export { extractClipMetadata } from "./extract-clip-metadata"
+export { htmlToPageContent } from "./html-to-page-content"
+export { sanitizeHtml } from "./sanitize-html"
+export { sanitizePageContent } from "./sanitize-page-content"
+export type {
+  AssembleClipDocumentInput,
+  ClipMetadata,
+  PageDocument,
+  PageDocumentNode,
+} from "./types"

--- a/packages/html-to-page/src/safe-url.ts
+++ b/packages/html-to-page/src/safe-url.ts
@@ -1,0 +1,38 @@
+const allowedProtocols = new Set(["http:", "https:"])
+
+export function parseAbsoluteUrl(value: string | null | undefined) {
+  if (!value) return null
+  try {
+    const url = new URL(value)
+    if (url.username || url.password) return null
+    return url
+  } catch {
+    return null
+  }
+}
+
+export function isAllowedHttpUrl(value: string | null | undefined) {
+  const url = parseAbsoluteUrl(value)
+  return Boolean(url && allowedProtocols.has(url.protocol))
+}
+
+export function isAllowedImageUrl(value: string | null | undefined) {
+  const url = parseAbsoluteUrl(value)
+  if (!url) return false
+  if (url.protocol === "data:") {
+    return url.pathname.startsWith("image/")
+  }
+  return allowedProtocols.has(url.protocol)
+}
+
+export function isAllowedEmbedSrc(value: string | null | undefined) {
+  const url = parseAbsoluteUrl(value)
+  if (!url || !allowedProtocols.has(url.protocol)) return false
+  const host = url.hostname.replace(/^www\./, "")
+  return (
+    host === "youtube.com" ||
+    host === "youtube-nocookie.com" ||
+    host === "player.vimeo.com" ||
+    host === "vimeo.com"
+  )
+}

--- a/packages/html-to-page/src/sanitize-html.ts
+++ b/packages/html-to-page/src/sanitize-html.ts
@@ -1,0 +1,110 @@
+import { isAllowedEmbedSrc, isAllowedHttpUrl, isAllowedImageUrl } from "./safe-url"
+
+const removedTags = new Set([
+  "script",
+  "style",
+  "noscript",
+  "template",
+  "link",
+  "meta",
+  "iframe",
+  "object",
+  "embed",
+  "form",
+  "input",
+  "button",
+  "textarea",
+  "select",
+])
+
+const allowedIframeTags = new Set(["iframe"])
+
+export function sanitizeHtml(html: string) {
+  const parser = new DOMParser()
+  const document = parser.parseFromString(
+    `<!doctype html><html><body>${html}</body></html>`,
+    "text/html",
+  )
+  const body = document.body
+  if (!body) return ""
+  sanitizeElement(body)
+  return body.innerHTML.trim()
+}
+
+function sanitizeElement(root: Element) {
+  const walker = Array.from(root.querySelectorAll("*"))
+
+  for (const element of walker) {
+    const tagName = element.tagName.toLowerCase()
+
+    if (tagName === "iframe") {
+      const src = element.getAttribute("src")
+      if (!isAllowedEmbedSrc(src)) {
+        element.remove()
+        continue
+      }
+      stripEventHandlers(element)
+      keepAttributes(element, ["src", "title", "width", "height", "allowfullscreen"])
+      continue
+    }
+
+    if (removedTags.has(tagName) && !allowedIframeTags.has(tagName)) {
+      element.remove()
+      continue
+    }
+
+    stripEventHandlers(element)
+
+    if (tagName === "a") {
+      const href = element.getAttribute("href")
+      if (!isAllowedHttpUrl(href)) {
+        unwrap(element)
+      }
+      continue
+    }
+
+    if (tagName === "img") {
+      const src = element.getAttribute("src")
+      if (!isAllowedImageUrl(src)) {
+        element.remove()
+      }
+      continue
+    }
+
+    if (tagName === "video") {
+      const src = element.getAttribute("src")
+      if (!isAllowedHttpUrl(src)) {
+        element.remove()
+      }
+    }
+  }
+}
+
+function stripEventHandlers(element: Element) {
+  for (const attribute of Array.from(element.attributes)) {
+    if (attribute.name.startsWith("on") || attribute.name === "srcdoc") {
+      element.removeAttribute(attribute.name)
+    }
+  }
+}
+
+function keepAttributes(element: Element, names: string[]) {
+  const allowed = new Set(names)
+  for (const attribute of Array.from(element.attributes)) {
+    if (!allowed.has(attribute.name)) {
+      element.removeAttribute(attribute.name)
+    }
+  }
+}
+
+function unwrap(element: Element) {
+  const parent = element.parentNode
+  if (!parent) {
+    element.remove()
+    return
+  }
+  while (element.firstChild) {
+    parent.insertBefore(element.firstChild, element)
+  }
+  element.remove()
+}

--- a/packages/html-to-page/src/sanitize-page-content.ts
+++ b/packages/html-to-page/src/sanitize-page-content.ts
@@ -1,0 +1,112 @@
+import {
+  isAllowedEmbedSrc,
+  isAllowedHttpUrl,
+  isAllowedImageUrl,
+} from "./safe-url"
+import type { PageDocument, PageDocumentNode } from "./types"
+
+const allowedNodeTypes = new Set([
+  "doc",
+  "paragraph",
+  "heading",
+  "blockquote",
+  "bulletList",
+  "orderedList",
+  "listItem",
+  "taskList",
+  "taskItem",
+  "codeBlock",
+  "horizontalRule",
+  "hardBreak",
+  "table",
+  "tableRow",
+  "tableHeader",
+  "tableCell",
+  "imageBlock",
+  "videoBlock",
+  "embedBlock",
+  "bookmarkBlock",
+  "text",
+])
+
+export function sanitizePageContent(document: PageDocument): PageDocument {
+  const content = document.content.flatMap((node) => sanitizeNode(node))
+  return {
+    type: "doc",
+    content: content.length > 0 ? content : [{ type: "paragraph" }],
+  }
+}
+
+function sanitizeNode(node: PageDocumentNode): PageDocumentNode[] {
+  if (node.type === "text") {
+    return node.text ? [{ ...node, marks: sanitizeMarks(node.marks) }] : []
+  }
+
+  if (!node.type || !allowedNodeTypes.has(node.type)) {
+    return node.content?.flatMap((child) => sanitizeNode(child)) ?? []
+  }
+
+  if (node.type === "imageBlock") {
+    const src = stringAttr(node.attrs, "src")
+    if (!isAllowedImageUrl(src)) return []
+    return [node]
+  }
+
+  if (node.type === "videoBlock") {
+    const src = stringAttr(node.attrs, "src")
+    if (!isAllowedHttpUrl(src)) return []
+    return [node]
+  }
+
+  if (node.type === "embedBlock") {
+    const src = stringAttr(node.attrs, "src")
+    if (!isAllowedEmbedSrc(src)) return []
+    return [node]
+  }
+
+  if (node.type === "bookmarkBlock") {
+    const href = stringAttr(node.attrs, "href")
+    if (!isAllowedHttpUrl(href)) return []
+    return [
+      {
+        ...node,
+        attrs: {
+          ...node.attrs,
+          href,
+          favicon: optionalAllowedUrl(node.attrs?.favicon, isAllowedHttpUrl),
+          image: optionalAllowedUrl(node.attrs?.image, isAllowedImageUrl),
+        },
+      },
+    ]
+  }
+
+  return [
+    {
+      ...node,
+      marks: sanitizeMarks(node.marks),
+      content: node.content?.flatMap((child) => sanitizeNode(child)),
+    },
+  ]
+}
+
+function sanitizeMarks(marks: PageDocumentNode["marks"]) {
+  if (!marks?.length) return marks
+  return marks.flatMap((mark) => {
+    if (mark.type !== "link") return [mark]
+    const href = stringAttr(mark.attrs, "href")
+    if (!isAllowedHttpUrl(href)) return []
+    return [{ ...mark, attrs: { ...mark.attrs, href } }]
+  })
+}
+
+function stringAttr(attrs: Record<string, unknown> | undefined, key: string) {
+  const value = attrs?.[key]
+  return typeof value === "string" ? value : null
+}
+
+function optionalAllowedUrl(
+  value: unknown,
+  allow: (value: string | null | undefined) => boolean,
+) {
+  return typeof value === "string" && allow(value) ? value : null
+}

--- a/packages/html-to-page/src/types.ts
+++ b/packages/html-to-page/src/types.ts
@@ -1,0 +1,43 @@
+export type PageDocumentMark = {
+  attrs?: Record<string, unknown>
+  type: string
+}
+
+export type PageDocumentNode = {
+  attrs?: Record<string, unknown>
+  content?: PageDocumentNode[]
+  marks?: PageDocumentMark[]
+  text?: string
+  type?: string
+}
+
+export type PageDocument = {
+  type: "doc"
+  content: PageDocumentNode[]
+}
+
+export type ClipMetadata = {
+  author: string | null
+  canonicalUrl: string | null
+  description: string | null
+  domain: string
+  favicon: string | null
+  image: string | null
+  published: string | null
+  selectionText: string | null
+  site: string | null
+  schemaType: string | null
+  title: string
+  url: string
+  wordCount: number
+}
+
+export type AssembleClipDocumentInput = {
+  content?: PageDocument | null
+  description?: string | null
+  favicon?: string | null
+  image?: string | null
+  note?: string | null
+  sourceUrl: string
+  title: string
+}

--- a/packages/html-to-page/tsconfig.json
+++ b/packages/html-to-page/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src"]
+}

--- a/scripts/refactor/check-architecture.mjs
+++ b/scripts/refactor/check-architecture.mjs
@@ -5,7 +5,7 @@ import ts from "typescript";
 
 const root = fileURLToPath(new URL("../../", import.meta.url));
 const baselinePath = join(root, "scripts/refactor/public-exports-baseline.json");
-const packages = ["apps/server", "packages/features", "packages/page-context", "packages/markdown-text-splitter", "packages/tiptap-comment-extension"];
+const packages = ["apps/server", "packages/features", "packages/html-to-page", "packages/page-context", "packages/markdown-text-splitter", "packages/tiptap-comment-extension"];
 
 function markdownFiles(directory) {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {


### PR DESCRIPTION
## Summary
- Adds the WXT Web Clipper extension (`apps/clipper`)
- Adds HTML-to-page conversion (`packages/html-to-page`) and `POST /clips`
- Saves pages from the browser with a workspace-scoped API key

## Test plan
- [ ] `npm test --workspace @zilobase/html-to-page`
- [ ] `npx vitest run apps/server/src/features/clips/build-clip-content.test.ts`
- [ ] `npm run build:clipper`
- [ ] Load unpacked from `apps/clipper/.output/chrome-mv3`, connect an API key, clip a page